### PR TITLE
Fixing some .NET 4.5 compat issues

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Auth/PublicKey.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/PublicKey.cs
@@ -12,7 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Security.Cryptography;
+#if NETSTANDARD1_5 || NETSTANDARD2_0
+using RSAKey = System.Security.Cryptography.RSA;
+#elif NET45
+using RSAKey = System.Security.Cryptography.RSACryptoServiceProvider;
+#else
+#error Unsupported target
+#endif
 
 namespace FirebaseAdmin.Auth
 {
@@ -27,12 +33,12 @@ namespace FirebaseAdmin.Auth
         public string Id { get; }
 
         /// <summary>
-        /// A <see cref="System.Security.Cryptography.RSA"/> instance containing the contents of
+        /// A <see cref="RSAKey"/> instance containing the contents of
         /// the public key.
         /// </summary>
-        public RSA RSA { get; }
+        public RSAKey RSA { get; }
 
-        public PublicKey(string keyId, RSA rsa)
+        public PublicKey(string keyId, RSAKey rsa)
         {
             Id = keyId;
             RSA = rsa;


### PR DESCRIPTION
Testing in a native Windows environment with .NET 4.5 revealed some incompatibility issues: https://ci.appveyor.com/project/hiranya911/firebase-admin-dotnet/build/1.0.1

This PR addresses those issues.
* Changes were originally staged on this fork: https://github.com/hiranya911/firebase-admin-dotnet/pull/1
* Successful build log: https://ci.appveyor.com/project/hiranya911/firebase-admin-dotnet/build/1.0.7

Fixes utilize the same technique employed in `Google.Apis` package: https://github.com/google/google-api-dotnet-client/blob/master/Src/Support/Google.Apis.Auth/OAuth2/ServiceAccountCredential.cs#L30