### PR TITLE
Reduce lock contention on HttpPublicKeySource.GetPublicKeysAsync

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -136,7 +136,7 @@ namespace FirebaseAdmin.Auth.Tests
             var canceller = new CancellationTokenSource();
             canceller.Cancel();
             var idToken = await FirebaseTokenVerifierTest.CreateTestTokenAsync();
-            await Assert.ThrowsAsync<OperationCanceledException>(
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
                 async () => await FirebaseAuth.DefaultInstance.VerifyIdTokenAsync(
                     idToken, canceller.Token));
         }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/HttpPublicKeySource.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/HttpPublicKeySource.cs
@@ -68,7 +68,7 @@ namespace FirebaseAdmin.Auth
         {
             if (_cachedKeys == null || _clock.UtcNow >= _expirationTime)
             {
-                await _lock.WaitAsync().ConfigureAwait(false);
+                await _lock.WaitAsync(cancellationToken).ConfigureAwait(false);
 
                 try
                 {
@@ -83,7 +83,7 @@ namespace FirebaseAdmin.Auth
                             _cachedKeys = ParseKeys(await response.Content.ReadAsStringAsync()
                                 .ConfigureAwait(false));
                             var cacheControl = response.Headers.CacheControl;
-                            if (cacheControl != null && cacheControl.MaxAge.HasValue)
+                            if (cacheControl?.MaxAge != null)
                             {
                                 _expirationTime = now.Add(cacheControl.MaxAge.Value)
                                     .Subtract(ClockSkew);


### PR DESCRIPTION
Implemented a double-checked lock so that the semaphore handle isn't obtained unless the token is null.