### PR TITLE
Some clean up and refactoring of existing FCM code

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
@@ -38,7 +38,7 @@ namespace FirebaseAdmin.IntegrationTests
                     Title = "Title",
                     Body = "Body",
                 },
-                AndroidConfig = new AndroidConfig()
+                Android = new AndroidConfig()
                 {
                     Priority = Priority.Normal,
                     TimeToLive = TimeSpan.FromHours(1),

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -26,7 +26,7 @@ namespace FirebaseAdmin.Messaging.Tests
         [Fact]
         public void MessageWithoutTarget()
         {
-            Assert.Throws<ArgumentException>(() => new Message().Validate());
+            Assert.Throws<ArgumentException>(() => new Message().CopyAndValidate());
         }
 
         [Fact]
@@ -50,21 +50,21 @@ namespace FirebaseAdmin.Messaging.Tests
                 Token = "test-token",
                 Topic = "test-topic",
             };
-            Assert.Throws<ArgumentException>(() => message.Validate());
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
 
             message = new Message()
             {
                 Token = "test-token",
                 Condition = "test-condition",
             };
-            Assert.Throws<ArgumentException>(() => message.Validate());
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
 
             message = new Message()
             {
                 Condition = "test-condition",
                 Topic = "test-topic",
             };
-            Assert.Throws<ArgumentException>(() => message.Validate());
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
 
             message = new Message()
             {
@@ -72,7 +72,19 @@ namespace FirebaseAdmin.Messaging.Tests
                 Topic = "test-topic",
                 Condition = "test-condition",
             };
-            Assert.Throws<ArgumentException>(() => message.Validate());
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+        }
+
+        [Fact]
+        public void MessageDeserialization()
+        {
+            var original = new Message()
+            {
+                Topic = "test-topic",
+            };
+            var json = NewtonsoftJsonSerializer.Instance.Serialize(original);
+            var copy = NewtonsoftJsonSerializer.Instance.Deserialize<Message>(json);
+            Assert.Equal(original.Topic, copy.Topic);
         }
 
         [Fact]
@@ -104,7 +116,7 @@ namespace FirebaseAdmin.Messaging.Tests
             foreach (var topic in topics)
             {
                 var message = new Message(){Topic = topic};
-                Assert.Throws<ArgumentException>(() => message.Validate());
+                Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
             }
         }
 
@@ -147,7 +159,7 @@ namespace FirebaseAdmin.Messaging.Tests
             var message = new Message()
             {
                 Topic = "test-topic",
-                AndroidConfig = new AndroidConfig()
+                Android = new AndroidConfig()
                 {
                     CollapseKey = "collapse-key",
                     Priority = Priority.High,
@@ -210,12 +222,36 @@ namespace FirebaseAdmin.Messaging.Tests
         }
 
         [Fact]
+        public void AndroidConfigMinimal()
+        {
+            var message = new Message()
+            {
+                Topic = "test-topic",
+                Android = new AndroidConfig()
+                {
+                    RestrictedPackageName = "test-pkg-name",
+                },
+            };
+            var expected = new JObject()
+            {
+                {"topic", "test-topic"},
+                {
+                    "android", new JObject()
+                    {
+                        { "restricted_package_name", "test-pkg-name" },
+                    }
+                },
+            };
+            AssertJsonEquals(expected, message);
+        }
+
+        [Fact]
         public void AndroidConfigFullSecondsTTL()
         {
             var message = new Message()
             {
                 Topic = "test-topic",
-                AndroidConfig = new AndroidConfig()
+                Android = new AndroidConfig()
                 {
                     TimeToLive = TimeSpan.FromHours(1),
                 },
@@ -226,7 +262,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 {
                     "android", new JObject()
                     {
-                        { "ttl", "3600s" },                        
+                        { "ttl", "3600s" },
                     }
                 },
             };
@@ -239,7 +275,7 @@ namespace FirebaseAdmin.Messaging.Tests
             var message = new Message()
             {
                 Topic = "test-topic",
-                AndroidConfig = new AndroidConfig()
+                Android = new AndroidConfig()
                 {
                     TimeToLive = TimeSpan.FromHours(-1),
                 },
@@ -250,11 +286,25 @@ namespace FirebaseAdmin.Messaging.Tests
                 {
                     "android", new JObject()
                     {
-                        { "ttl", "3600s" },                        
+                        { "ttl", "3600s" },
                     }
                 },
             };
-            Assert.Throws<ArgumentException>(() => message.Validate());
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+        }
+
+        [Fact]
+        public void AndroidConfigDeserialization()
+        {
+            var original = new AndroidConfig()
+            {
+                TimeToLive = TimeSpan.FromSeconds(10.5),
+                Priority = Priority.High,
+            };
+            var json = NewtonsoftJsonSerializer.Instance.Serialize(original);
+            var copy = NewtonsoftJsonSerializer.Instance.Deserialize<AndroidConfig>(json);
+            Assert.Equal(original.Priority, copy.Priority);
+            Assert.Equal(original.TimeToLive, copy.TimeToLive);
         }
 
         [Fact]
@@ -263,7 +313,7 @@ namespace FirebaseAdmin.Messaging.Tests
             var message = new Message()
             {
                 Topic = "test-topic",
-                AndroidConfig = new AndroidConfig()
+                Android = new AndroidConfig()
                 {
                     Notification = new AndroidNotification()
                     {
@@ -271,7 +321,7 @@ namespace FirebaseAdmin.Messaging.Tests
                     },
                 },
             };
-            Assert.Throws<ArgumentException>(() => message.Validate());
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
         }
 
         [Fact]
@@ -280,7 +330,7 @@ namespace FirebaseAdmin.Messaging.Tests
             var message = new Message()
             {
                 Topic = "test-topic",
-                AndroidConfig = new AndroidConfig()
+                Android = new AndroidConfig()
                 {
                     Notification = new AndroidNotification()
                     {
@@ -288,7 +338,7 @@ namespace FirebaseAdmin.Messaging.Tests
                     },
                 },
             };
-            Assert.Throws<ArgumentException>(() => message.Validate());
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
         }
 
         [Fact]
@@ -297,7 +347,7 @@ namespace FirebaseAdmin.Messaging.Tests
             var message = new Message()
             {
                 Topic = "test-topic",
-                AndroidConfig = new AndroidConfig()
+                Android = new AndroidConfig()
                 {
                     Notification = new AndroidNotification()
                     {
@@ -305,12 +355,12 @@ namespace FirebaseAdmin.Messaging.Tests
                     },
                 },
             };
-            Assert.Throws<ArgumentException>(() => message.Validate());
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
         }
 
         private void AssertJsonEquals(JObject expected, Message actual)
         {
-            var json = NewtonsoftJsonSerializer.Instance.Serialize(actual.Validate());
+            var json = NewtonsoftJsonSerializer.Instance.Serialize(actual.CopyAndValidate());
             var parsed = JObject.Parse(json);
             Assert.True(
                 JToken.DeepEquals(expected, parsed),

--- a/FirebaseAdmin/FirebaseAdmin/Extensions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Extensions.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -84,6 +85,20 @@ namespace FirebaseAdmin
         public static long UnixTimestamp(this IClock clock)
         {
             return (long) (clock.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
+        }
+
+        /// <summary>
+        /// Creates a shallow copy of a collection of key-value pairs.
+        /// </summary>
+        public static IReadOnlyDictionary<TKey, TValue> Copy<TKey, TValue>(
+            this IEnumerable<KeyValuePair<TKey, TValue>> source)
+        {
+            var copy = new Dictionary<TKey, TValue>();
+            foreach (var entry in source)
+            {
+                copy[entry.Key] = entry.Value;
+            }
+            return copy;
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Extensions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Extensions.cs
@@ -48,7 +48,7 @@ namespace FirebaseAdmin
         /// <summary>
         /// Creates a default (unauthenticated) <see cref="ConfigurableHttpClient"/> from the
         /// factory.
-        /// </summary> 
+        /// </summary>
         public static ConfigurableHttpClient CreateDefaultHttpClient(
             this HttpClientFactory clientFactory)
         {
@@ -99,6 +99,14 @@ namespace FirebaseAdmin
                 copy[entry.Key] = entry.Value;
             }
             return copy;
+        }
+
+        /// <summary>
+        /// Creates a shallow copy of a collection of items.
+        /// </summary>
+        public static IEnumerable<T> Copy<T>(this IEnumerable<T> source)
+        {
+            return new List<T>(source);
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidConfig.cs
@@ -28,54 +28,21 @@ namespace FirebaseAdmin.Messaging
         /// messages that can be collapsed, so that only the last message gets sent when delivery can be
         /// resumed. A maximum of 4 different collapse keys may be active at any given time.
         /// </summary>
+        [JsonProperty("collapse_key")]
         public string CollapseKey { get; set; }
 
         /// <summary>
         /// The priority of the message.
         /// </summary>
+        [JsonIgnore]
         public Priority? Priority { get; set; }
-
-        /// <summary>
-        /// The time-to-live duration of the message.
-        /// </summary>
-        public TimeSpan TimeToLive { get; set; }
-
-        /// <summary>
-        /// The package name of the application where the registration tokens must match in order
-        /// to receive the message.
-        /// </summary>
-        public string RestrictedPackageName { get; set; }
-
-        /// <summary>
-        /// A collection of key-value pairs that will be added to the message as data fields. Keys
-        /// and the values must not be null. When set, overrides any data fields set on the top-level
-        /// <see cref="Message"/>.
-        /// </summary>
-        public IReadOnlyDictionary<string, string> Data { get; set; }
-
-        /// <summary>
-        /// The Android notification to be included in the message.
-        /// </summary>
-        public AndroidNotification Notification { get; set; }
-
-        internal ValidatedAndroidConfig Validate()
-        {
-            return new ValidatedAndroidConfig()
-            {
-                CollapseKey = this.CollapseKey,
-                Priority = this.PriorityString,
-                TimeToLive = this.TtlString,
-                RestrictedPackageName = this.RestrictedPackageName,
-                Data = this.Data,
-                Notification = this.Notification?.Validate(),
-            };
-        }
 
         /// <summary>
         /// String representation of the <see cref="Priority"/> as accepted by the FCM backend
         /// service.
         /// </summary>
-        private string PriorityString
+        [JsonProperty("priority")]
+        internal string PriorityString
         {
             get
             {
@@ -89,14 +56,33 @@ namespace FirebaseAdmin.Messaging
                         return null;
                 }
             }
+            set
+            {
+                switch (value)
+                {
+                    case "high":
+                        Priority = Messaging.Priority.High;
+                        return;
+                    case "normal":
+                        Priority = Messaging.Priority.High;
+                        return;
+                }
+            }
         }
+
+        /// <summary>
+        /// The time-to-live duration of the message.
+        /// </summary>
+        [JsonIgnore]
+        public TimeSpan? TimeToLive { get; set; }
 
         /// <summary>
         /// String representation of <see cref="TimeToLive"/> as accepted by the FCM backend
         /// service. The string ends in the suffix "s" (indicating seconds) and is preceded
         /// by the number of seconds, with nanoseconds expressed as fractional seconds.
         /// </summary>
-        private string TtlString
+        [JsonProperty("ttl")]
+        internal string TtlString
         {
             get
             {
@@ -104,11 +90,7 @@ namespace FirebaseAdmin.Messaging
                 {
                     return null;
                 }
-                var totalSeconds = TimeToLive.TotalSeconds;
-                if (totalSeconds < 0)
-                {
-                    throw new ArgumentException("TTL must not be negative.");
-                }
+                var totalSeconds = TimeToLive.Value.TotalSeconds;
                 var seconds = (long) Math.Floor(totalSeconds);
                 var subsecondNanos = (long) ((totalSeconds - seconds) * 1e9);
                 if (subsecondNanos > 0)
@@ -117,44 +99,78 @@ namespace FirebaseAdmin.Messaging
                 }
                 return String.Format("{0}s", seconds);
             }
+            set
+            {
+                var segments = value.TrimEnd('s').Split('.');
+                var seconds = Int64.Parse(segments[0]);
+                var ttl = TimeSpan.FromSeconds(seconds);
+                if (segments.Length == 2)
+                {
+                    var subsecondNanos = Int64.Parse(segments[1].TrimStart('0'));
+                    ttl = ttl.Add(TimeSpan.FromMilliseconds(subsecondNanos / 1e6));
+                }
+                TimeToLive = ttl;
+            }
+        }
+
+        /// <summary>
+        /// The package name of the application where the registration tokens must match in order
+        /// to receive the message.
+        /// </summary>
+        [JsonProperty("restricted_package_name")]
+        public string RestrictedPackageName { get; set; }
+
+        /// <summary>
+        /// A collection of key-value pairs that will be added to the message as data fields. Keys
+        /// and the values must not be null. When set, overrides any data fields set on the top-level
+        /// <see cref="Message"/>.
+        /// </summary>
+        [JsonProperty("data")]
+        public IReadOnlyDictionary<string, string> Data { get; set; }
+
+        /// <summary>
+        /// The Android notification to be included in the message.
+        /// </summary>
+        [JsonProperty("notification")]
+        public AndroidNotification Notification { get; set; }
+
+        /// <summary>
+        /// Copies this Android config, and validates the content of it to ensure that it can be
+        /// serialized into the JSON format expected by the FCM service.
+        /// </summary>
+        internal AndroidConfig CopyAndValidate()
+        {
+            // Copy and validate the leaf-level properties
+            var copy = new AndroidConfig()
+            {
+                CollapseKey = this.CollapseKey,
+                Priority = this.Priority,
+                TimeToLive = this.TimeToLive,
+                RestrictedPackageName = this.RestrictedPackageName,
+                Data = this.Data?.Copy(),
+            };
+            var totalSeconds = copy.TimeToLive?.TotalSeconds ?? 0;
+            if (totalSeconds < 0)
+            {
+                throw new ArgumentException("TTL must not be negative.");
+            }
+
+            // Copy and validate the child properties
+            copy.Notification = this.Notification?.CopyAndValidate();
+            return copy;
         }
     }
-
-    /// <summary>
-    /// Represents a validated Android configuration that can be serialized into the JSON format
-    /// accepted by the FCM backend service.
-    /// </summary>
-    internal sealed class ValidatedAndroidConfig
-    {
-        [JsonProperty("collapse_key")]
-        internal string CollapseKey { get; set; }
-        
-        [JsonProperty("priority")]
-        internal string Priority { get; set; }
-        
-        [JsonProperty("ttl")]
-        internal string TimeToLive { get; set; }
-
-        [JsonProperty("restricted_package_name")]
-        internal string RestrictedPackageName { get; set; }
-
-        [JsonProperty("data")]
-        internal IReadOnlyDictionary<string, string> Data { get; set; }
-
-        [JsonProperty("notification")]
-        internal ValidatedAndroidNotification Notification { get; set; }
-     }
 
     /// <summary>
     /// Priority levels that can be set on an <see cref="AndroidConfig"/>.
     /// </summary>
     public enum Priority
-    {        
+    {
         /// <summary>
         /// High priority message.
         /// </summary>
         High,
-        
+
         /// <summary>
         /// Normal priority message.
         /// </summary>

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
@@ -26,7 +26,7 @@ namespace FirebaseAdmin.Messaging
     /// </summary>
     public sealed class AndroidNotification
     {
-        
+
         /// <summary>
         /// The title of the Android notification. When provided, overrides the title set
         /// via <see cref="Notification.Title"/>.
@@ -128,9 +128,9 @@ namespace FirebaseAdmin.Messaging
                 Tag = this.Tag,
                 ClickAction = this.ClickAction,
                 TitleLocKey = this.TitleLocKey,
-                TitleLocArgs = this.TitleLocArgs,
+                TitleLocArgs = this.TitleLocArgs?.Copy(),
                 BodyLocKey = this.BodyLocKey,
-                BodyLocArgs = this.BodyLocArgs,
+                BodyLocArgs = this.BodyLocArgs?.Copy(),
                 ChannelId = this.ChannelId,
             };
             if (copy.Color != null && !Regex.Match(copy.Color, "^#[0-9a-fA-F]{6}$").Success)

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
@@ -31,39 +31,46 @@ namespace FirebaseAdmin.Messaging
         /// The title of the Android notification. When provided, overrides the title set
         /// via <see cref="Notification.Title"/>.
         /// </summary>
+        [JsonProperty("title")]
         public string Title { get; set; }
 
         /// <summary>
         /// The title of the Android notification. When provided, overrides the title set
         /// via <see cref="Notification.Body"/>.
         /// </summary>
+        [JsonProperty("body")]
         public string Body { get; set; }
 
         /// <summary>
         /// The icon of the Android notification.
         /// </summary>
+        [JsonProperty("icon")]
         public string Icon { get; set; }
 
         /// <summary>
         /// The notification icon color. Must be of the form <code>#RRGGBB</code>.
         /// </summary>
+        [JsonProperty("color")]
         public string Color { get; set; }
 
         /// <summary>
         /// The sound to be played when the device receives the notification.
         /// </summary>
+        [JsonProperty("sound")]
         public string Sound { get; set; }
 
         /// <summary>
         /// The notification tag. This is an identifier used to replace existing notifications in
         /// the notification drawer. If not specified, each request creates a new notification.
         /// </summary>
+        [JsonProperty("tag")]
         public string Tag { get; set; }
 
         /// <summary>
         /// The action associated with a user click on the notification. If specified, an activity
         /// with a matching Intent Filter is launched when a user clicks on the notification.
         /// </summary>
+        [JsonProperty("click_action")]
         public string ClickAction { get; set; }
 
         /// <summary>
@@ -71,12 +78,14 @@ namespace FirebaseAdmin.Messaging
         /// title text.
         /// <see cref="Message"/>.
         /// </summary>
+        [JsonProperty("title_loc_key")]
         public string TitleLocKey { get; set; }
 
         /// <summary>
         /// The collection of resource key strings that will be used in place of the format
         /// specifiers in <see cref="TitleLocKey"/>.
         /// </summary>
+        [JsonProperty("title_loc_args")]
         public IEnumerable<string> TitleLocArgs { get; set; }
 
         /// <summary>
@@ -84,12 +93,14 @@ namespace FirebaseAdmin.Messaging
         /// body text.
         /// <see cref="Message"/>.
         /// </summary>
+        [JsonProperty("body_loc_key")]
         public string BodyLocKey { get; set; }
 
         /// <summary>
         /// The collection of resource key strings that will be used in place of the format
         /// specifiers in <see cref="BodyLocKey"/>.
         /// </summary>
+        [JsonProperty("body_loc_args")]
         public IEnumerable<string> BodyLocArgs { get; set; }
 
         /// <summary>
@@ -98,34 +109,16 @@ namespace FirebaseAdmin.Messaging
         /// If you don't send this channel ID in the request, or if the channel ID provided has
         /// not yet been created by the app, FCM uses the channel ID specified in the app manifest.
         /// </summary>
+        [JsonProperty("channel_id")]
         public string ChannelId { get; set; }
 
         /// <summary>
-        /// Validates the content and structure of this notification, and converts it into the
-        /// <see cref="ValidatedAndroidNotification"/> type. This return type can be safely
-        /// serialized into a JSON string that is acceptable to the FCM backend service.
+        /// Copies this notification, and validates the content of it to ensure that it can be
+        /// serialized into the JSON format expected by the FCM service.
         /// </summary>
-        internal ValidatedAndroidNotification Validate()
+        internal AndroidNotification CopyAndValidate()
         {
-            if (Color != null) {
-                if (!Regex.Match(Color, "^#[0-9a-fA-F]{6}$").Success)
-                {
-                    throw new ArgumentException("Color must be in the form #RRGGBB");
-                }
-            }
-            if (TitleLocArgs != null && TitleLocArgs.Any()) {
-                if (string.IsNullOrEmpty(TitleLocKey))
-                {
-                    throw new ArgumentException("TitleLocKey is required when specifying TitleLocArgs");
-                }
-            }
-            if (BodyLocArgs != null && BodyLocArgs.Any()) {
-                if (string.IsNullOrEmpty(BodyLocKey))
-                {
-                    throw new ArgumentException("BodyLocKey is required when specifying BodyLocArgs");
-                }
-            }
-            return new ValidatedAndroidNotification()
+            var copy = new AndroidNotification()
             {
                 Title = this.Title,
                 Body = this.Body,
@@ -140,49 +133,25 @@ namespace FirebaseAdmin.Messaging
                 BodyLocArgs = this.BodyLocArgs,
                 ChannelId = this.ChannelId,
             };
+            if (copy.Color != null && !Regex.Match(copy.Color, "^#[0-9a-fA-F]{6}$").Success)
+            {
+                throw new ArgumentException("Color must be in the form #RRGGBB");
+            }
+            if (copy.TitleLocArgs != null && copy.TitleLocArgs.Any())
+            {
+                if (string.IsNullOrEmpty(copy.TitleLocKey))
+                {
+                    throw new ArgumentException("TitleLocKey is required when specifying TitleLocArgs");
+                }
+            }
+            if (copy.BodyLocArgs != null && copy.BodyLocArgs.Any())
+            {
+                if (string.IsNullOrEmpty(copy.BodyLocKey))
+                {
+                    throw new ArgumentException("BodyLocKey is required when specifying BodyLocArgs");
+                }
+            }
+            return copy;
         }
-    }
-
-    /// <summary>
-    /// Represents a validated Android notification that can be serialized into the JSON format
-    /// accepted by the FCM backend service.
-    /// </summary>
-    internal sealed class ValidatedAndroidNotification
-    {
-        [JsonProperty("title")]
-        internal string Title { get; set; }
-
-        [JsonProperty("body")]
-        internal string Body { get; set; }
-
-        [JsonProperty("icon")]
-        internal string Icon { get; set; }
-
-        [JsonProperty("color")]
-        internal string Color { get; set; }
-
-        [JsonProperty("sound")]
-        internal string Sound { get; set; }
-
-        [JsonProperty("tag")]
-        internal string Tag { get; set; }
-
-        [JsonProperty("click_action")]
-        internal string ClickAction { get; set; }
-
-        [JsonProperty("title_loc_key")]
-        internal string TitleLocKey { get; set; }
-
-        [JsonProperty("title_loc_args")]
-        internal IEnumerable<string> TitleLocArgs { get; set; }
-
-        [JsonProperty("body_loc_key")]
-        internal string BodyLocKey { get; set; }
-
-        [JsonProperty("body_loc_args")]
-        internal IEnumerable<string> BodyLocArgs { get; set; }
-
-        [JsonProperty("channel_id")]
-        internal string ChannelId { get; set; }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessagingClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessagingClient.cs
@@ -74,7 +74,7 @@ namespace FirebaseAdmin.Messaging
         {
             var request = new SendRequest()
             {
-                Message = message.ThrowIfNull(nameof(message)).Validate(),
+                Message = message.ThrowIfNull(nameof(message)).CopyAndValidate(),
                 ValidateOnly = dryRun,
             };
             try
@@ -111,7 +111,7 @@ namespace FirebaseAdmin.Messaging
     internal sealed class SendRequest
     {
         [Newtonsoft.Json.JsonProperty("message")]
-        public ValidatedMessage Message { get; set; }
+        public Message Message { get; set; }
 
         [Newtonsoft.Json.JsonProperty("validate_only")]
         public bool ValidateOnly { get; set; }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
@@ -18,7 +18,6 @@ using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Google.Apis.Json;
 using Google.Apis.Util;
-using FirebaseAdmin;
 
 namespace FirebaseAdmin.Messaging
 {
@@ -92,9 +91,9 @@ namespace FirebaseAdmin.Messaging
 
         /// <summary>
         /// Copies this message, and validates the content of it to ensure that it can be
-        /// serialized into the JSON format expected by the FCM service. Each property is
-        /// copied before validated to make sure the original is not modified in the user
-        /// code post-validation.
+        /// serialized into the JSON format expected by the FCM service. Each property is copied
+        /// before validation to guard against the original being modified in the user code
+        /// post-validation.
         /// </summary>
         internal Message CopyAndValidate()
         {

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
@@ -33,46 +33,82 @@ namespace FirebaseAdmin.Messaging
         /// <summary>
         /// The registration token of the device to which the message should be sent.
         /// </summary>
+        [JsonProperty("token")]
         public string Token { get; set; }
 
         /// <summary>
         /// The name of the FCM topic to which the message should be sent. Topic names may
         /// contain the <c>/topics/</c> prefix.
         /// </summary>
+        [JsonIgnore]
         public string Topic { get; set; }
+
+        /// <summary>
+        /// Formatted representation of the <see cref="Topic"/>. Removes the <code>/topics/</code>
+        /// prefix if present. This is what's ultimately sent to the FCM service.
+        /// </summary>
+        [JsonProperty("topic")]
+        internal string UnprefixedTopic
+        {
+            get
+            {
+                if (Topic != null && Topic.StartsWith("/topics/"))
+                {
+                    return Topic.Substring("/topics/".Length);
+                }
+                return Topic;
+            }
+            set
+            {
+                Topic = value;
+            }
+        }
 
         /// <summary>
         /// The FCM condition to which the message should be sent. Must be a valid condition
         /// string such as <c>"'foo' in topics"</c>.
         /// </summary>
+        [JsonProperty("condition")]
         public string Condition { get; set; }
 
         /// <summary>
         /// A collection of key-value pairs that will be added to the message as data fields. Keys
         /// and the values must not be null.
         /// </summary>
+        [JsonProperty("data")]
         public IReadOnlyDictionary<string, string> Data { get; set; }
 
         /// <summary>
         /// The notification information to be included in the message.
         /// </summary>
+        [JsonProperty("notification")]
         public Notification Notification { get; set; }
 
         /// <summary>
         /// The Android-specific information to be included in the message.
         /// </summary>
-        public AndroidConfig AndroidConfig { get; set; }
+        [JsonProperty("android")]
+        public AndroidConfig Android { get; set; }
 
         /// <summary>
-        /// Validates the content and structure of this message instance, and converts it into the
-        /// <see cref="ValidatedMessage"/> type. This return type can be safely serialized into
-        /// a JSON string that is acceptable to the FCM backend service.
+        /// Copies this message, and validates the content of it to ensure that it can be
+        /// serialized into the JSON format expected by the FCM service. Each property is
+        /// copied before validated to make sure the original is not modified in the user
+        /// code post-validation.
         /// </summary>
-        internal ValidatedMessage Validate()
+        internal Message CopyAndValidate()
         {
+            // Copy and validate the leaf-level properties
+            var copy = new Message()
+            {
+                Token = this.Token,
+                Topic = this.Topic,
+                Condition = this.Condition,
+                Data = this.Data?.Copy(),
+            };
             var list = new List<string>()
             {
-                Token, Topic, Condition,
+                copy.Token, copy.Topic, copy.Condition,
             };
             var targets = list.FindAll((target) => !string.IsNullOrEmpty(target));
             if (targets.Count != 1)
@@ -80,66 +116,16 @@ namespace FirebaseAdmin.Messaging
                 throw new ArgumentException(
                     "Exactly one of Token, Topic or Condition is required.");
             }
-            return new ValidatedMessage()
+            var topic = copy.UnprefixedTopic;
+            if (topic != null && !Regex.IsMatch(topic, "^[a-zA-Z0-9-_.~%]+$"))
             {
-                Token = this.Token,
-                Topic = this.ValidatedTopic,
-                Condition = this.Condition,
-                Data = this.Data,
-                Notification = this.Notification,
-                AndroidConfig = this.AndroidConfig?.Validate(),
-            };
-        }
-
-        /// <summary>
-        /// Validated and formatted representation of the <see cref="Topic"/>. Checks for any
-        /// illegal characters in the topic name, and removes the <code>/topics/</code> prefix if
-        /// present.
-        /// </summary>
-        private string ValidatedTopic
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(Topic))
-                {
-                    return null;
-                }
-                var topic = Topic;
-                if (topic.StartsWith("/topics/"))
-                {
-                    topic = topic.Substring("/topics/".Length);
-                }
-                if (!Regex.IsMatch(topic, "^[a-zA-Z0-9-_.~%]+$"))
-                {
-                    throw new ArgumentException("Malformed topic name.");
-                }
-                return topic;
+                throw new ArgumentException("Malformed topic name.");
             }
+
+            // Copy and validate the child properties
+            copy.Notification = this.Notification?.CopyAndValidate();
+            copy.Android = this.Android?.CopyAndValidate();
+            return copy;
         }
-    }
-
-    /// <summary>
-    /// Represents a validated message that can be serialized into the JSON format accepted by the
-    /// FCM backend service.
-    /// </summary>
-    internal sealed class ValidatedMessage
-    {
-        [JsonProperty("token")]
-        internal string Token { get; set; }
-
-        [JsonProperty("topic")]
-        internal string Topic { get; set; }
-
-        [JsonProperty("condition")]
-        internal string Condition { get; set; }
-
-        [JsonProperty("data")]
-        internal IReadOnlyDictionary<string, string> Data { get; set; }
-
-        [JsonProperty("notification")]
-        internal Notification Notification { get; set; }
-
-        [JsonProperty("android")]
-        internal ValidatedAndroidConfig AndroidConfig { get; set; }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/Notification.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/Notification.cs
@@ -32,5 +32,18 @@ namespace FirebaseAdmin.Messaging
         /// </summary>
         [JsonProperty("body")]
         public string Body { get; set; }
+
+        /// <summary>
+        /// Copies this notification. There is nothing to be validated in this class, but we use
+        /// the same method name as in other classes in this namespace.
+        /// </summary>
+        internal Notification CopyAndValidate()
+        {
+            return new Notification()
+            {
+                Title = this.Title,
+                Body = this.Body,
+            };
+        }
     }
 }


### PR DESCRIPTION
1. Renamed `Message.AndroidConfig` property to `Message.Android` (to be consistent with the proposal go/dotnet-fcm).
2. Removed the internal `Validated*` types, and absorbed the corresponding serialization/deserialization logic into the existing public types.
3. Implemented stronger copy-and-validate semantics for messages. Each message property is copied prior to validation. This ensures that any mutations done by user code to the original `Message` or its properties, won't affect the json posted to the FCM service.