### PR TITLE
Refactoring the user management code

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -69,6 +69,8 @@ namespace FirebaseAdmin.Auth.Tests
                 async () => await auth.CreateCustomTokenAsync("user"));
             await Assert.ThrowsAsync<InvalidOperationException>(
                 async () => await auth.VerifyIdTokenAsync("user"));
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await auth.SetCustomUserClaimsAsync("user", null));
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
@@ -321,15 +321,8 @@ namespace FirebaseAdmin.Auth
             lock (this.authLock)
             {
                 this.deleted = true;
-                if (this.tokenFactory.IsValueCreated)
-                {
-                    this.tokenFactory.Value.Dispose();
-                }
-
-                if (this.userManager.IsValueCreated)
-                {
-                    this.userManager.Value.Dispose();
-                }
+                this.tokenFactory.DisposeIfCreated();
+                this.userManager.DisposeIfCreated();
             }
         }
 

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseUserManager.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseUserManager.cs
@@ -74,7 +74,7 @@ namespace FirebaseAdmin.Auth
             const string updatePath = "accounts:update";
             var response = await this.PostAndDeserializeAsync<JObject>(
                 updatePath, user, cancellationToken).ConfigureAwait(false);
-            if (response["localId"]?.Value<string>() != user.Uid)
+            if (user.Uid != (string)response["localId"])
             {
                 throw new FirebaseException($"Failed to update user: {user.Uid}");
             }

--- a/FirebaseAdmin/FirebaseAdmin/Extensions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Extensions.cs
@@ -93,10 +93,24 @@ namespace FirebaseAdmin
         public static async Task<HttpResponseMessage> PostJsonAsync<T>(
             this HttpClient client, string requestUri, T body, CancellationToken cancellationToken)
         {
-            var payload = NewtonsoftJsonSerializer.Instance.Serialize(body);
-            var content = new StringContent(payload, Encoding.UTF8, "application/json");
+            var content = NewtonsoftJsonSerializer.Instance.CreateJsonHttpContent(body);
             return await client.PostAsync(requestUri, content, cancellationToken)
                 .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Serializes the <paramref name="body"/> into JSON, and wraps the result in an instance
+        /// of <see cref="HttpContent"/>, which can be included in an outgoing HTTP request.
+        /// </summary>
+        /// <returns>An instance of <see cref="HttpContent"/> containing the JSON representation
+        /// of <paramref name="body"/>.</returns>
+        /// <param name="serializer">The JSON serializer to serialize the given object.</param>
+        /// <param name="body">The object that will be serialized into JSON.</param>
+        public static HttpContent CreateJsonHttpContent(
+            this NewtonsoftJsonSerializer serializer, object body)
+        {
+            var payload = serializer.Serialize(body);
+            return new StringContent(payload, Encoding.UTF8, "application/json");
         }
 
         /// <summary>

--- a/FirebaseAdmin/FirebaseAdmin/Extensions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Extensions.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Google.Apis.Auth.OAuth2;
@@ -93,7 +94,7 @@ namespace FirebaseAdmin
             this HttpClient client, string requestUri, T body, CancellationToken cancellationToken)
         {
             var payload = NewtonsoftJsonSerializer.Instance.Serialize(body);
-            var content = new StringContent(payload, System.Text.Encoding.UTF8, "application/json");
+            var content = new StringContent(payload, Encoding.UTF8, "application/json");
             return await client.PostAsync(requestUri, content, cancellationToken)
                 .ConfigureAwait(false);
         }
@@ -107,6 +108,20 @@ namespace FirebaseAdmin
         {
             var timeSinceEpoch = clock.UtcNow.Subtract(new DateTime(1970, 1, 1));
             return (long)timeSinceEpoch.TotalSeconds;
+        }
+
+        /// <summary>
+        /// Disposes a lazy-initialized object if the object has already been created.
+        /// </summary>
+        /// <param name="lazy">The lazy initializer containing a disposable object.</param>
+        /// <typeparam name="T">Type of the object that needs to be disposed.</typeparam>
+        public static void DisposeIfCreated<T>(this Lazy<T> lazy)
+        where T : IDisposable
+        {
+            if (lazy.IsValueCreated)
+            {
+                lazy.Value.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
* Making the user management initialization thread-safe
* Cleaning up the lazy loading code, and the `FirebaseAuth.Delete()`.
* Exposing a new `FirebaseAuth.SetCustomUserClaimsAsync()` method that accepts a cancellation token as a second argument.
* Introducing a couple of helper functions to `Extensions` to make it easier to send JSON requests, and tear down managed resources.