### PR TITLE
Fixing a couple of lint errors for .NET 4.5

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseTokenVerifier.cs
@@ -219,7 +219,7 @@ namespace FirebaseAdmin.Auth
                     hash, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
 #elif NET45
                 key.Id == keyId &&
-                    ((RSACryptoServiceProvider) key.RSA).VerifyHash(hash, Sha256Oid, signature)
+                    ((RSACryptoServiceProvider)key.RSA).VerifyHash(hash, Sha256Oid, signature)
 #else
 #error Unsupported target
 #endif

--- a/FirebaseAdmin/FirebaseAdmin/Auth/HttpPublicKeySource.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/HttpPublicKeySource.cs
@@ -121,7 +121,7 @@ namespace FirebaseAdmin.Auth
 #if NETSTANDARD1_5 || NETSTANDARD2_0
                 rsa = x509cert.GetRSAPublicKey();
 #elif NET45
-                rsa = (RSAKey) x509cert.PublicKey.Key;
+                rsa = (RSAKey)x509cert.PublicKey.Key;
 #else
 #error Unsupported target
 #endif


### PR DESCRIPTION
These lint errors popped up when compiling for .NET 4.5:

```
Auth/HttpPublicKeySource.cs(124,30): error SA1009: Closing parenthesis should not be followed by a space. [/usr/local/google/home/hkj/Projects/firebase-admin-dotnet/public/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj]
Auth/FirebaseTokenVerifier.cs(222,47): error SA1003: Operator '(RSACryptoServiceProvider)' should not be followed by whitespace. [/usr/local/google/home/hkj/Projects/firebase-admin-dotnet/public/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj]
Auth/HttpPublicKeySource.cs(124,30): error SA1003: Operator '(RSAKey)' should not be followed by whitespace. [/usr/local/google/home/hkj/Projects/firebase-admin-dotnet/public/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj]
```

Fixed by this PR.