### PR TITLE
 Tolerating a 5 minute clock skew when verifying JWTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
--
+- [fixed] The `VerifyIdToken()Async` function fnow tolerates a clock skew of up to
+  5 minutes when comparing JWT timestamps.
 
 # v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
-- [fixed] The `VerifyIdToken()Async` function fnow tolerates a clock skew of up to
-  5 minutes when comparing JWT timestamps.
+- [fixed] The `VerifyIdTokenAsync()` function fnow tolerates a clock skew of up
+  to 5 minutes when comparing JWT timestamps.
 
 # v1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- [fixed] The `VerifyIdTokenAsync()` function fnow tolerates a clock skew of up
+- [fixed] The `VerifyIdTokenAsync()` function now tolerates a clock skew of up
   to 5 minutes when comparing JWT timestamps.
 
 # v1.2.0

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseTokenVerifierTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseTokenVerifierTest.cs
@@ -30,6 +30,8 @@ namespace FirebaseAdmin.Auth.Tests
 {
     public class FirebaseTokenVerifierTest : IDisposable
     {
+        private const long ClockSkewSeconds = 5 * 60;
+
         private static readonly IPublicKeySource KeySource = new FileSystemPublicKeySource(
             "./resources/public_cert.pem");
 
@@ -132,7 +134,7 @@ namespace FirebaseAdmin.Auth.Tests
         {
             var payload = new Dictionary<string, object>()
             {
-                { "exp", Clock.UnixTimestamp() - 60 },
+                { "exp", Clock.UnixTimestamp() - (ClockSkewSeconds + 1) },
             };
             var idToken = await CreateTestTokenAsync(payloadOverrides: payload);
             await Assert.ThrowsAsync<FirebaseException>(
@@ -140,15 +142,47 @@ namespace FirebaseAdmin.Auth.Tests
         }
 
         [Fact]
+        public async Task ExpiryTimeInAcceptableRange()
+        {
+            var expiryTimeSeconds = Clock.UnixTimestamp() - ClockSkewSeconds;
+            var payload = new Dictionary<string, object>()
+            {
+                { "exp", expiryTimeSeconds },
+            };
+            var idToken = await CreateTestTokenAsync(payloadOverrides: payload);
+
+            var decoded = await TokenVerifier.VerifyTokenAsync(idToken);
+
+            Assert.Equal("testuser", decoded.Uid);
+            Assert.Equal(expiryTimeSeconds, decoded.ExpirationTimeSeconds);
+        }
+
+        [Fact]
         public async Task InvalidIssuedAt()
         {
             var payload = new Dictionary<string, object>()
             {
-                { "iat", Clock.UnixTimestamp() + 60 },
+                { "iat", Clock.UnixTimestamp() + (ClockSkewSeconds + 1) },
             };
             var idToken = await CreateTestTokenAsync(payloadOverrides: payload);
             await Assert.ThrowsAsync<FirebaseException>(
                 async () => await TokenVerifier.VerifyTokenAsync(idToken));
+        }
+
+        [Fact]
+        public async Task IssuedAtInAcceptableRange()
+        {
+            var issuedAtSeconds = Clock.UnixTimestamp() + ClockSkewSeconds;
+            var payload = new Dictionary<string, object>()
+            {
+                { "iat", issuedAtSeconds },
+            };
+            var idToken = await CreateTestTokenAsync(payloadOverrides: payload);
+
+            var decoded = await TokenVerifier.VerifyTokenAsync(idToken);
+
+            Assert.Equal("testuser", decoded.Uid);
+            Assert.Equal(issuedAtSeconds, decoded.IssuedAtTimeSeconds);
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseTokenVerifier.cs
@@ -159,13 +159,13 @@ namespace FirebaseAdmin.Auth
             else if (payload.IssuedAtTimeSeconds - ClockSkewSeconds > currentTimeInSeconds)
             {
                 error = $"Firebase {this.shortName} issued at future timestamp "
-                    + $"{payload.IssuedAtTimeSeconds}. Expected to be greater than "
+                    + $"{payload.IssuedAtTimeSeconds}. Expected to be less than "
                     + $"{currentTimeInSeconds}.";
             }
             else if (payload.ExpirationTimeSeconds + ClockSkewSeconds < currentTimeInSeconds)
             {
                 error = $"Firebase {this.shortName} expired at {payload.ExpirationTimeSeconds}. "
-                    + $" Expected to be less than ${currentTimeInSeconds}.";
+                    + $"Expected to be greater than {currentTimeInSeconds}.";
             }
             else if (string.IsNullOrEmpty(payload.Subject))
             {


### PR DESCRIPTION
* Adding a 5 minute tolerance to timestamp comparisons
* Updated error messages to include more details

Resolves #28 