### PR TITLE
Changed <see href> tags to <a tags> in API docs

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Messaging/ApnsConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/ApnsConfig.cs
@@ -22,8 +22,8 @@ namespace FirebaseAdmin.Messaging
 {
     /// <summary>
     /// Represents the APNS-specific options that can be included in a <see cref="Message"/>. Refer
-    /// to <see href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html">
-    /// APNs documentation</see> for various headers and payload fields supported by APNS.
+    /// to <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html">
+    /// APNs documentation</a> for various headers and payload fields supported by APNS.
     /// </summary>
     public sealed class ApnsConfig
     {

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/Aps.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/Aps.cs
@@ -21,8 +21,8 @@ using Newtonsoft.Json;
 namespace FirebaseAdmin.Messaging
 {
     /// <summary>
-    /// Represents the <see href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html">
-    /// aps dictionary</see> that is part of every APNs message.
+    /// Represents the <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html">
+    /// aps dictionary</a> that is part of every APNs message.
     /// </summary>
     public sealed class Aps
     {

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/ApsAlert.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/ApsAlert.cs
@@ -20,8 +20,8 @@ using Newtonsoft.Json;
 namespace FirebaseAdmin.Messaging
 {
     /// <summary>
-    /// Represents the <see href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW5">
-    /// alert property</see> that can be included in the <c>aps</c> dictionary of an APNs
+    /// Represents the <a href="https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW5">
+    /// alert property</a> that can be included in the <c>aps</c> dictionary of an APNs
     /// payload.
     /// </summary>
     public sealed class ApsAlert

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushConfig.cs
@@ -39,13 +39,13 @@ namespace FirebaseAdmin.Messaging
         public IReadOnlyDictionary<string, string> Data { get; set; }
 
         /// <summary>
-        /// Gets or sets the Webpush notification that will be included in the message.
+        /// Gets or sets the Webpush notification included in the message.
         /// </summary>
         [JsonProperty("notification")]
         public WebpushNotification Notification { get; set; }
 
         /// <summary>
-        /// Gets or sets the Webpush options that will be included in the message.
+        /// Gets or sets the Webpush options included in the message.
         /// </summary>
         [JsonProperty("fcm_options")]
         public WebpushFcmOptions FcmOptions { get; set; }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushConfig.cs
@@ -25,8 +25,8 @@ namespace FirebaseAdmin.Messaging
     {
         /// <summary>
         /// Gets or sets the Webpush HTTP headers. Refer
-        /// <see href="https://tools.ietf.org/html/rfc8030#section-5">
-        /// Webpush specification</see> for supported headers.
+        /// <a href="https://tools.ietf.org/html/rfc8030#section-5">
+        /// Webpush specification</a> for supported headers.
         /// </summary>
         [JsonProperty("headers")]
         public IReadOnlyDictionary<string, string> Headers { get; set; }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushFcmOptions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushFcmOptions.cs
@@ -19,7 +19,8 @@ namespace FirebaseAdmin.Messaging
 {
     /// <summary>
     /// Represents the Webpush-specific notification options that can be included in a <see cref="Message"/>.
-    /// See <see href="https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#WebpushFcmOptions">this link</see>.
+    /// See <a href="https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#WebpushFcmOptions">REST
+    /// API reference</a> for a list of supported fields.
     /// </summary>
     public sealed class WebpushFcmOptions
     {

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushNotification.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushNotification.cs
@@ -23,8 +23,8 @@ namespace FirebaseAdmin.Messaging
     /// <summary>
     /// Represents the Webpush-specific notification options that can be included in a
     /// <see cref="Message"/>. Supports most standard options defined in the
-    /// <see href="https://developer.mozilla.org/en-US/docs/Web/API/notification/Notification">
-    /// Web Notification specification</see>.
+    /// <a href="https://developer.mozilla.org/en-US/docs/Web/API/notification/Notification">
+    /// Web Notification specification</a>.
     /// </summary>
     public sealed class WebpushNotification
     {


### PR DESCRIPTION
It turns out tools like Doxygen do not correctly render `<see href>` tags in API references. See the intro section of this page for an example: https://firebase.google.com/docs/reference/admin/dotnet/class/firebase-admin/messaging/aps

This PR changes the API docs to use `<a href>` tags instead. The resulting documentation displays the external links correctly: https://firebase.devsite.corp.google.com/docs/reference/admin/dotnet/class/firebase-admin/messaging/aps