### PR TITLE
Updated license package expression

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
@@ -17,7 +17,7 @@
     <PackageTags>firebase;Google;Cloud</PackageTags>
     <Copyright>Copyright 2018 Google LLC</Copyright>
     <Authors>Google Inc.</Authors>
-    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Firebase/firebase-admin-dotnet</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/Firebase/firebase-admin-dotnet</RepositoryUrl>


### PR DESCRIPTION
LicenseURL config is being deprecated. LicenseExpression is the new recommended way to specify license details: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file