### PR TITLE
Implemented ErrorHandlingHttpClient for easy and typesafe error handling

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessagingErrorHandlerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessagingErrorHandlerTest.cs
@@ -50,8 +50,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 Content = new StringContent(json, Encoding.UTF8, "application/json"),
             };
 
-            var handler = new MessagingErrorHandler();
-            var error = Assert.Throws<FirebaseMessagingException>(() => handler.ThrowIfError(resp, json));
+            var error = MessagingErrorHandler.Instance.HandleHttpErrorResponse(resp, json);
 
             Assert.Equal(ErrorCode.Unavailable, error.ErrorCode);
             Assert.Equal("Test error message", error.Message);
@@ -82,8 +81,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 Content = new StringContent(json, Encoding.UTF8, "application/json"),
             };
 
-            var handler = new MessagingErrorHandler();
-            var error = Assert.Throws<FirebaseMessagingException>(() => handler.ThrowIfError(resp, json));
+            var error = MessagingErrorHandler.Instance.HandleHttpErrorResponse(resp, json);
 
             Assert.Equal(ErrorCode.PermissionDenied, error.ErrorCode);
             Assert.Equal("Test error message", error.Message);
@@ -113,8 +111,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 Content = new StringContent(json, Encoding.UTF8, "application/json"),
             };
 
-            var handler = new MessagingErrorHandler();
-            var error = Assert.Throws<FirebaseMessagingException>(() => handler.ThrowIfError(resp, json));
+            var error = MessagingErrorHandler.Instance.HandleHttpErrorResponse(resp, json);
 
             Assert.Equal(ErrorCode.PermissionDenied, error.ErrorCode);
             Assert.Equal("Test error message", error.Message);
@@ -133,8 +130,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 Content = new StringContent(json, Encoding.UTF8, "application/json"),
             };
 
-            var handler = new MessagingErrorHandler();
-            var error = Assert.Throws<FirebaseMessagingException>(() => handler.ThrowIfError(resp, json));
+            var error = MessagingErrorHandler.Instance.HandleHttpErrorResponse(resp, json);
 
             Assert.Equal(ErrorCode.Unavailable, error.ErrorCode);
             Assert.Equal(

--- a/FirebaseAdmin/FirebaseAdmin.Tests/PlatformErrorHandlerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/PlatformErrorHandlerTest.cs
@@ -21,6 +21,8 @@ namespace FirebaseAdmin.Tests
 {
     public class PlatformErrorHandlerTest
     {
+        private static readonly TestPlatformErrorHandler ErrorHandler = new TestPlatformErrorHandler();
+
         [Fact]
         public void PlatformError()
         {
@@ -36,8 +38,7 @@ namespace FirebaseAdmin.Tests
                 Content = new StringContent(json, Encoding.UTF8, "application/json"),
             };
 
-            var handler = new PlatformErrorHandler();
-            var error = Assert.Throws<FirebaseException>(() => handler.ThrowIfError(resp, json));
+            var error = ErrorHandler.HandleHttpErrorResponse(resp, json);
 
             Assert.Equal(ErrorCode.Unavailable, error.ErrorCode);
             Assert.Equal("Test error message", error.Message);
@@ -55,8 +56,7 @@ namespace FirebaseAdmin.Tests
                 Content = new StringContent(text, Encoding.UTF8, "text/plain"),
             };
 
-            var handler = new PlatformErrorHandler();
-            var error = Assert.Throws<FirebaseException>(() => handler.ThrowIfError(resp, text));
+            var error = ErrorHandler.HandleHttpErrorResponse(resp, text);
 
             Assert.Equal(ErrorCode.Unavailable, error.ErrorCode);
             Assert.Equal(
@@ -80,8 +80,7 @@ namespace FirebaseAdmin.Tests
                 Content = new StringContent(json, Encoding.UTF8, "application/json"),
             };
 
-            var handler = new PlatformErrorHandler();
-            var error = Assert.Throws<FirebaseException>(() => handler.ThrowIfError(resp, json));
+            var error = ErrorHandler.HandleHttpErrorResponse(resp, json);
 
             Assert.Equal(ErrorCode.Unavailable, error.ErrorCode);
             Assert.Equal("Test error message", error.Message);
@@ -103,8 +102,7 @@ namespace FirebaseAdmin.Tests
                 Content = new StringContent(json, Encoding.UTF8, "application/json"),
             };
 
-            var handler = new PlatformErrorHandler();
-            var error = Assert.Throws<FirebaseException>(() => handler.ThrowIfError(resp, json));
+            var error = ErrorHandler.HandleHttpErrorResponse(resp, json);
 
             Assert.Equal(ErrorCode.InvalidArgument, error.ErrorCode);
             Assert.Equal(
@@ -124,8 +122,7 @@ namespace FirebaseAdmin.Tests
                 Content = new StringContent(json, Encoding.UTF8, "application/json"),
             };
 
-            var handler = new PlatformErrorHandler();
-            var error = Assert.Throws<FirebaseException>(() => handler.ThrowIfError(resp, json));
+            var error = ErrorHandler.HandleHttpErrorResponse(resp, json);
 
             Assert.Equal(ErrorCode.Unavailable, error.ErrorCode);
             Assert.Equal(
@@ -133,6 +130,14 @@ namespace FirebaseAdmin.Tests
                 error.Message);
             Assert.Same(resp, error.HttpResponse);
             Assert.Null(error.InnerException);
+        }
+
+        private class TestPlatformErrorHandler : PlatformErrorHandler<FirebaseException>
+        {
+            protected override FirebaseException CreateException(FirebaseExceptionArgs args)
+            {
+                return new FirebaseException(args.Code, args.Message, response: args.HttpResponse);
+            }
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Util/ErrorHandlingHttpClientTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Util/ErrorHandlingHttpClientTest.cs
@@ -1,0 +1,279 @@
+// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FirebaseAdmin.Tests;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Http;
+using Google.Apis.Json;
+using Xunit;
+
+namespace FirebaseAdmin.Util.Tests
+{
+    public class ErrorHandlingHttpClientTest
+    {
+        [Fact]
+        public async Task SuccessfulRequest()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Response = @"{""foo"": ""bar""}",
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var httpClient = new ErrorHandlingHttpClient<FirebaseException>(
+                this.CreateArgs(factory));
+
+            var response = await httpClient.SendAndDeserializeAsync<Dictionary<string, string>>(
+                this.CreateRequest());
+
+            Assert.NotNull(response.HttpResponse);
+            Assert.Equal(handler.Response, response.Body);
+            Assert.Single(response.Result);
+            Assert.Equal("bar", response.Result["foo"]);
+            Assert.Equal(1, handler.Calls);
+        }
+
+        [Fact]
+        public async Task SuccessfulAuthorizedRequest()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Response = @"{""foo"": ""bar""}",
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var credential = GoogleCredential.FromAccessToken("test-token");
+            var httpClient = new ErrorHandlingHttpClient<FirebaseException>(
+                this.CreateArgs(factory, credential));
+
+            var response = await httpClient.SendAndDeserializeAsync<Dictionary<string, string>>(
+                this.CreateRequest());
+
+            Assert.NotNull(response.HttpResponse);
+            Assert.Equal(handler.Response, response.Body);
+            Assert.Single(response.Result);
+            Assert.Equal("bar", response.Result["foo"]);
+            Assert.Equal(1, handler.Calls);
+            Assert.Equal(
+                "Bearer test-token",
+                handler.LastRequestHeaders.GetValues("Authorization").First());
+        }
+
+        [Fact]
+        public async Task NetworkError()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Exception = new HttpRequestException("Low-level network error"),
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var httpClient = new ErrorHandlingHttpClient<FirebaseException>(
+                this.CreateArgs(factory));
+
+            var exception = await Assert.ThrowsAsync<FirebaseException>(
+                async () => await httpClient.SendAndDeserializeAsync<Dictionary<string, string>>(
+                    this.CreateRequest()));
+
+            Assert.Equal(ErrorCode.Unknown, exception.ErrorCode);
+            Assert.Equal("Network error", exception.Message);
+            Assert.Same(handler.Exception, exception.InnerException);
+            Assert.Null(exception.HttpResponse);
+        }
+
+        [Fact]
+        public async Task ErrorResponse()
+        {
+            var handler = new MockMessageHandler()
+            {
+                StatusCode = HttpStatusCode.InternalServerError,
+                Response = "{}",
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var httpClient = new ErrorHandlingHttpClient<FirebaseException>(
+                this.CreateArgs(factory));
+
+            var exception = await Assert.ThrowsAsync<FirebaseException>(
+                async () => await httpClient.SendAndDeserializeAsync<Dictionary<string, string>>(
+                    this.CreateRequest()));
+
+            Assert.Equal(ErrorCode.Internal, exception.ErrorCode);
+            Assert.Equal("Example error message: {}", exception.Message);
+            Assert.Null(exception.InnerException);
+            Assert.NotNull(exception.HttpResponse);
+        }
+
+        [Fact]
+        public async Task DeserializeError()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Response = "not json",
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var httpClient = new ErrorHandlingHttpClient<FirebaseException>(
+                this.CreateArgs(factory));
+
+            var exception = await Assert.ThrowsAsync<FirebaseException>(
+                async () => await httpClient.SendAndDeserializeAsync<Dictionary<string, string>>(
+                    this.CreateRequest()));
+
+            Assert.Equal(ErrorCode.Unknown, exception.ErrorCode);
+            Assert.Equal("Response parse error", exception.Message);
+            Assert.NotNull(exception.InnerException);
+            Assert.NotNull(exception.HttpResponse);
+        }
+
+        [Fact]
+        public async Task CustomDeserializer()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Response = @"{""foo"": ""bar""}",
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var deserializer = new TestResponseDeserializer();
+            var args = this.CreateArgs(factory);
+            args.Deserializer = deserializer;
+            var httpClient = new ErrorHandlingHttpClient<FirebaseException>(args);
+
+            var response = await httpClient.SendAndDeserializeAsync<Dictionary<string, string>>(
+                this.CreateRequest());
+
+            Assert.NotNull(response.HttpResponse);
+            Assert.Equal(handler.Response, response.Body);
+            Assert.Single(response.Result);
+            Assert.Equal("bar", response.Result["foo"]);
+            Assert.Equal(1, handler.Calls);
+            Assert.Equal(1, deserializer.Count);
+        }
+
+        [Fact]
+        public void NoHttpClientFactory()
+        {
+            var args = this.CreateArgs(null);
+
+            Assert.Throws<ArgumentNullException>(
+                () => new ErrorHandlingHttpClient<FirebaseException>(args));
+        }
+
+        [Fact]
+        public void NoRequestExceptionHandler()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Response = "{}",
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var args = this.CreateArgs(factory);
+            args.RequestExceptionHandler = null;
+
+            Assert.Throws<ArgumentNullException>(
+                () => new ErrorHandlingHttpClient<FirebaseException>(args));
+        }
+
+        [Fact]
+        public void NoDeserializeExceptionHandler()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Response = "{}",
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var args = this.CreateArgs(factory);
+            args.DeserializeExceptionHandler = null;
+
+            Assert.Throws<ArgumentNullException>(
+                () => new ErrorHandlingHttpClient<FirebaseException>(args));
+        }
+
+        [Fact]
+        public void NoErrorResponseHandler()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Response = "{}",
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var args = this.CreateArgs(factory);
+            args.ErrorResponseHandler = null;
+
+            Assert.Throws<ArgumentNullException>(
+                () => new ErrorHandlingHttpClient<FirebaseException>(args));
+        }
+
+        private ErrorHandlingHttpClientArgs<FirebaseException> CreateArgs(
+            HttpClientFactory factory, GoogleCredential credential = null)
+        {
+            return new ErrorHandlingHttpClientArgs<FirebaseException>()
+            {
+                HttpClientFactory = factory,
+                Credential = credential,
+                ErrorResponseHandler = new TestHttpErrorResponseHandler(),
+                RequestExceptionHandler = new TestRequestExceptionHandler(),
+                DeserializeExceptionHandler = new TestDeserializeExceptionHandler(),
+            };
+        }
+
+        private HttpRequestMessage CreateRequest()
+        {
+            return new HttpRequestMessage()
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri("https://firebase.google.com"),
+            };
+        }
+
+        private class TestHttpErrorResponseHandler : IHttpErrorResponseHandler<FirebaseException>
+        {
+            public FirebaseException HandleHttpErrorResponse(HttpResponseMessage response, string body)
+            {
+                return new FirebaseException(
+                    ErrorCode.Internal, $"Example error message: {body}", response: response);
+            }
+        }
+
+        private class TestDeserializeExceptionHandler : IDeserializeExceptionHandler<FirebaseException>
+        {
+            public FirebaseException HandleDeserializeException(
+                Exception exception, ResponseInfo responseInfo)
+            {
+                return new FirebaseException(
+                    ErrorCode.Unknown, "Response parse error", exception, responseInfo.HttpResponse);
+            }
+        }
+
+        private class TestRequestExceptionHandler : IHttpRequestExceptionHandler<FirebaseException>
+        {
+            public FirebaseException HandleHttpRequestException(HttpRequestException exception)
+            {
+                return new FirebaseException(ErrorCode.Unknown, "Network error", exception);
+            }
+        }
+
+        private class TestResponseDeserializer : IHttpResponseDeserializer
+        {
+            internal int Count { get; private set; }
+
+            public T Deserialize<T>(string body)
+            {
+                this.Count++;
+                return NewtonsoftJsonSerializer.Instance.Deserialize<T>(body);
+            }
+        }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Util/ErrorHandlingHttpClientTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Util/ErrorHandlingHttpClientTest.cs
@@ -216,6 +216,24 @@ namespace FirebaseAdmin.Util.Tests
                 () => new ErrorHandlingHttpClient<FirebaseException>(args));
         }
 
+        [Fact]
+        public async Task Dispose()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Response = @"{}",
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var httpClient = new ErrorHandlingHttpClient<FirebaseException>(
+                this.CreateArgs(factory));
+
+            httpClient.Dispose();
+
+            await Assert.ThrowsAsync<ObjectDisposedException>(
+                async () => await httpClient.SendAndDeserializeAsync<Dictionary<string, string>>(
+                this.CreateRequest()));
+        }
+
         private ErrorHandlingHttpClientArgs<FirebaseException> CreateArgs(
             HttpClientFactory factory, GoogleCredential credential = null)
         {

--- a/FirebaseAdmin/FirebaseAdmin/HttpErrorHandler.cs
+++ b/FirebaseAdmin/FirebaseAdmin/HttpErrorHandler.cs
@@ -16,13 +16,15 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using FirebaseAdmin.Util;
 
 namespace FirebaseAdmin
 {
     /// <summary>
     /// Base class for handling HTTP error responses.
     /// </summary>
-    internal class HttpErrorHandler
+    internal abstract class HttpErrorHandler<T> : IHttpErrorResponseHandler<T>
+    where T : FirebaseException
     {
         private static readonly IReadOnlyDictionary<HttpStatusCode, ErrorCode> HttpErrorCodes =
             new Dictionary<HttpStatusCode, ErrorCode>()
@@ -37,23 +39,10 @@ namespace FirebaseAdmin
                 { HttpStatusCode.ServiceUnavailable, ErrorCode.Unavailable },
             };
 
-        /// <summary>
-        /// Parses the given HTTP response and throws a <see cref="FirebaseException"/> if it
-        /// contains an error. Does nothing if the status code of the HTTP response indicates
-        /// success.
-        /// </summary>
-        /// <param name="response">HTTP response message to process.</param>
-        /// <param name="body">The response body read from the message.</param>
-        /// <exception cref="FirebaseException">If the response contains an error.</exception>
-        internal void ThrowIfError(HttpResponseMessage response, string body)
+        public T HandleHttpErrorResponse(HttpResponseMessage response, string body)
         {
-            if (response.IsSuccessStatusCode)
-            {
-                return;
-            }
-
             var args = this.CreateExceptionArgs(response, body);
-            throw this.CreateException(args);
+            return this.CreateException(args);
         }
 
         /// <summary>
@@ -89,10 +78,7 @@ namespace FirebaseAdmin
         /// <param name="args">A <see cref="FirebaseExceptionArgs"/> instance containing error
         /// code, message and other details.</param>
         /// <returns>A <see cref="FirebaseException"/> object.</returns>
-        protected virtual FirebaseException CreateException(FirebaseExceptionArgs args)
-        {
-            return new FirebaseException(args.Code, args.Message, response: args.HttpResponse);
-        }
+        protected abstract T CreateException(FirebaseExceptionArgs args);
 
         internal sealed class FirebaseExceptionArgs
         {

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using Google.Apis.Http;
 
 namespace FirebaseAdmin.Messaging
 {
@@ -31,7 +30,7 @@ namespace FirebaseAdmin.Messaging
         private FirebaseMessaging(FirebaseApp app)
         {
             this.messagingClient = new FirebaseMessagingClient(
-                    app.Options.HttpClientFactory, app.Options.Credential, app.GetProjectId());
+                app.Options.HttpClientFactory, app.Options.Credential, app.GetProjectId());
         }
 
         /// <summary>

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
@@ -15,8 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
-using Google.Apis.Json;
-using Google.Apis.Util;
 using Newtonsoft.Json;
 
 namespace FirebaseAdmin.Messaging

--- a/FirebaseAdmin/FirebaseAdmin/PlatformErrorHandler.cs
+++ b/FirebaseAdmin/FirebaseAdmin/PlatformErrorHandler.cs
@@ -24,9 +24,10 @@ namespace FirebaseAdmin
     /// See <a href="https://cloud.google.com/apis/design/errors">Errors</a> for more details on
     /// how Google Cloud Platform APIs report back error codes and details. If this class fails
     /// to determine an error code or message from a given API response, it falls back to the
-    /// error handling logic defined in the parent <see cref="HttpErrorHandler"/> class.
+    /// error handling logic defined in the parent <see cref="HttpErrorHandler{T}"/> class.
     /// </summary>
-    internal class PlatformErrorHandler : HttpErrorHandler
+    internal abstract class PlatformErrorHandler<T> : HttpErrorHandler<T>
+    where T : FirebaseException
     {
         private static readonly IReadOnlyDictionary<string, ErrorCode> PlatformErrorCodes =
             new Dictionary<string, ErrorCode>()
@@ -38,7 +39,8 @@ namespace FirebaseAdmin
                 { "UNAVAILABLE", ErrorCode.Unavailable },
             };
 
-        protected sealed override FirebaseExceptionArgs CreateExceptionArgs(HttpResponseMessage response, string body)
+        protected sealed override FirebaseExceptionArgs CreateExceptionArgs(
+            HttpResponseMessage response, string body)
         {
             var parsedResponse = this.ParseResponseBody(body);
             var status = parsedResponse.Error?.Status ?? string.Empty;

--- a/FirebaseAdmin/FirebaseAdmin/Util/DeserializedResponseInfo.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/DeserializedResponseInfo.cs
@@ -1,0 +1,31 @@
+// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace FirebaseAdmin.Util
+{
+    /// <summary>
+    /// HTTP response and the body string read from it. Additionally also contains a
+    /// deserialized representation of the body.
+    /// </summary>
+    internal sealed class DeserializedResponseInfo<T> : ResponseInfo
+    {
+        internal DeserializedResponseInfo(ResponseInfo info, T result)
+        : base(info)
+        {
+            this.Result = result;
+        }
+
+        internal T Result { get; private set; }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Util/ErrorHandlingHttpClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/ErrorHandlingHttpClient.cs
@@ -1,0 +1,117 @@
+// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Google.Apis.Json;
+using Google.Apis.Util;
+
+namespace FirebaseAdmin.Util
+{
+    /// <summary>
+    /// An HTTP client wrapper that handles various exceptions by turning them into the suitable
+    /// instances of <see cref="FirebaseException"/>. Specifically, this implementation handles
+    /// low-level network exceptions, HTTP error responses (non 2xx responses), and response
+    /// deserialization exceptions.
+    /// </summary>
+    /// <typeparam name="T">Subtype of <see cref="FirebaseException"/> raised by this
+    /// HTTP client.</typeparam>
+    internal sealed class ErrorHandlingHttpClient<T> : IDisposable
+    where T : FirebaseException
+    {
+        private readonly HttpClient httpClient;
+        private readonly IHttpResponseDeserializer deserializer;
+        private readonly IHttpErrorResponseHandler<T> errorResponseHandler;
+        private readonly IHttpRequestExceptionHandler<T> requestExceptionHandler;
+        private readonly IDeserializeExceptionHandler<T> deserializeExceptionHandler;
+
+        internal ErrorHandlingHttpClient(ErrorHandlingHttpClientArgs<T> args)
+        {
+            var credential = args.Credential;
+            var clientFactory = args.HttpClientFactory.ThrowIfNull(nameof(args.HttpClientFactory));
+            if (credential != null)
+            {
+                this.httpClient = clientFactory.CreateAuthorizedHttpClient(credential);
+            }
+            else
+            {
+                this.httpClient = clientFactory.CreateDefaultHttpClient();
+            }
+
+            this.deserializer = args.Deserializer ?? JsonResponseDeserializer.Instance;
+            this.errorResponseHandler = args.ErrorResponseHandler.ThrowIfNull(
+                nameof(args.ErrorResponseHandler));
+            this.requestExceptionHandler = args.RequestExceptionHandler.ThrowIfNull(
+                nameof(args.RequestExceptionHandler));
+            this.deserializeExceptionHandler = args.DeserializeExceptionHandler.ThrowIfNull(
+                nameof(args.DeserializeExceptionHandler));
+        }
+
+        public void Dispose()
+        {
+            this.httpClient.Dispose();
+        }
+
+        internal async Task<DeserializedResponseInfo<TResult>> SendAndDeserializeAsync<TResult>(
+            HttpRequestMessage request, CancellationToken cancellationToken = default)
+        {
+            var info = await this.SendAndReadAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                var result = this.deserializer.Deserialize<TResult>(info.Body);
+                return new DeserializedResponseInfo<TResult>(info, result);
+            }
+            catch (Exception e)
+            {
+                throw this.deserializeExceptionHandler.HandleDeserializeException(e, info);
+            }
+        }
+
+        private async Task<ResponseInfo> SendAndReadAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var response = await this.httpClient.SendAsync(request, cancellationToken)
+                    .ConfigureAwait(false);
+                var body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw this.errorResponseHandler.HandleHttpErrorResponse(response, body);
+                }
+
+                return new ResponseInfo(response, body);
+            }
+            catch (HttpRequestException e)
+            {
+                throw this.requestExceptionHandler.HandleHttpRequestException(e);
+            }
+        }
+
+        private sealed class JsonResponseDeserializer : IHttpResponseDeserializer
+        {
+            internal static readonly JsonResponseDeserializer Instance = new JsonResponseDeserializer();
+
+            private JsonResponseDeserializer() { }
+
+            public TResult Deserialize<TResult>(string body)
+            {
+                return NewtonsoftJsonSerializer.Instance.Deserialize<TResult>(body);
+            }
+        }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Util/ErrorHandlingHttpClientArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/ErrorHandlingHttpClientArgs.cs
@@ -1,0 +1,40 @@
+// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Http;
+
+namespace FirebaseAdmin.Util
+{
+    /// <summary>
+    /// Arguments for constructing an instance of <see cref="ErrorHandlingHttpClient{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">Subtype of <see cref="FirebaseException"/> raised by the
+    /// HTTP client constructed using these arguments.</typeparam>
+    internal sealed class ErrorHandlingHttpClientArgs<T>
+    where T : FirebaseException
+    {
+        internal HttpClientFactory HttpClientFactory { get; set; }
+
+        internal GoogleCredential Credential { get; set; }
+
+        internal IHttpResponseDeserializer Deserializer { get; set; }
+
+        internal IHttpErrorResponseHandler<T> ErrorResponseHandler { get; set; }
+
+        internal IHttpRequestExceptionHandler<T> RequestExceptionHandler { get; set; }
+
+        internal IDeserializeExceptionHandler<T> DeserializeExceptionHandler { get; set; }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Util/IDeserializeExceptionHandler.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/IDeserializeExceptionHandler.cs
@@ -1,0 +1,36 @@
+// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace FirebaseAdmin.Util
+{
+    /// <summary>
+    /// An interface for handling HTTP response deserialization (unmarshalling) errors.
+    /// </summary>
+    /// <typeparam name="T">Subtype of <see cref="FirebaseException"/> raised by this
+    /// error handler.</typeparam>
+    internal interface IDeserializeExceptionHandler<T>
+    where T : FirebaseException
+    {
+        /// <summary>
+        /// Handles the exceptions occured while deserializing HTTP response payloads, and turns
+        /// them into appropriate instances of <see cref="FirebaseException"/>.
+        /// </summary>
+        /// <returns>A <see cref="FirebaseException"/> instance.</returns>
+        /// <param name="exception">The exception encountered during deserialization.</param>
+        /// <param name="responseInfo">The HTTP response that triggered the exception.</param>
+        T HandleDeserializeException(Exception exception, ResponseInfo responseInfo);
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Util/IHttpErrorResponseHandler.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/IHttpErrorResponseHandler.cs
@@ -1,0 +1,36 @@
+// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+
+namespace FirebaseAdmin.Util
+{
+    /// <summary>
+    /// An interface for handling HTTP error responses returned by services.
+    /// </summary>
+    /// <typeparam name="T">Subtype of <see cref="FirebaseException"/> raised by this
+    /// error handler.</typeparam>
+    internal interface IHttpErrorResponseHandler<T>
+    where T : FirebaseException
+    {
+        /// <summary>
+        /// Handles the HTTP error responses returned by a service, and turns them into the
+        /// appropriate instances of <see cref="FirebaseException"/>.
+        /// </summary>
+        /// <returns>A <see cref="FirebaseException"/> instance.</returns>
+        /// <param name="response">The HTTP response.</param>
+        /// <param name="body">The response payload read from the response.</param>
+        T HandleHttpErrorResponse(HttpResponseMessage response, string body);
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Util/IHttpRequestExceptionHandler.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/IHttpRequestExceptionHandler.cs
@@ -1,0 +1,36 @@
+// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+
+namespace FirebaseAdmin.Util
+{
+    /// <summary>
+    /// An interface for handling <see cref="HttpRequestException"/> instances encountered while
+    /// sending HTTP requests.
+    /// </summary>
+    /// <typeparam name="T">Subtype of <see cref="FirebaseException"/> raised by this
+    /// error handler.</typeparam>
+    internal interface IHttpRequestExceptionHandler<T>
+    where T : FirebaseException
+    {
+        /// <summary>
+        /// Handles the exceptions occured while sending HTTP requests, and turns
+        /// them into appropriate instances of <see cref="FirebaseException"/>.
+        /// </summary>
+        /// <returns>A <see cref="FirebaseException"/> instance.</returns>
+        /// <param name="exception">The exception encountered while sending a request.</param>
+        T HandleHttpRequestException(HttpRequestException exception);
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Util/IHttpResponseDeserializer.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/IHttpResponseDeserializer.cs
@@ -1,0 +1,30 @@
+// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace FirebaseAdmin.Util
+{
+    /// <summary>
+    /// An interface for deserializing string payloads read from HTTP response.
+    /// </summary>
+    internal interface IHttpResponseDeserializer
+    {
+        /// <summary>
+        /// Deserializes an HTTP response payload into the specified type.
+        /// </summary>
+        /// <returns>The deserialized object instance.</returns>
+        /// <param name="body">The response payload to deserialize.</param>
+        /// <typeparam name="T">Type to deserialize the response into.</typeparam>
+        T Deserialize<T>(string body);
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Util/ResponseInfo.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/ResponseInfo.cs
@@ -1,0 +1,38 @@
+// Copyright 2019, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Net.Http;
+using Google.Apis.Util;
+
+namespace FirebaseAdmin.Util
+{
+    /// <summary>
+    /// HTTP response and the body string read from it.
+    /// </summary>
+    internal class ResponseInfo
+    {
+        internal ResponseInfo(HttpResponseMessage response, string body)
+        {
+            this.HttpResponse = response.ThrowIfNull(nameof(response));
+            this.Body = body.ThrowIfNull(nameof(body));
+        }
+
+        internal ResponseInfo(ResponseInfo other)
+        : this(other.HttpResponse, other.Body) { }
+
+        internal HttpResponseMessage HttpResponse { get; private set; }
+
+        internal string Body { get; private set; }
+    }
+}


### PR DESCRIPTION
Following pattern is pretty common in the SDK:

1. Make an HTTP call and read the response to memory.
2. Handle any HTTP error responses.
3. Deserialize the success response.

Each of the above steps can throw exceptions, which we must catch and expose wrapped in the appropriate `FirebaseException` subclass. In this PR I'm implementing a flexible and typesafe framework to implement this pattern.

PR highlights:
1. A new `ErrorHandlingHttpClient<T>` class that will catch various exceptions and rethrow them as instances of `T`.
2. Three new interfaces that can be used to configure the error handling behavior of `ErrorHandlingHttpClient`:
  - `IHttpRequestExceptionHandler<T>`
  - `IHttpErrorResponseHandler<T>`
  - `IDeserializeExceptionHandler<T>`
3. The existing `HttpErrorHandler` has been made to implement `IHttpErrorResponseHandler`. 

Benefits:
1. The above mentioned pattern needs to be implemented in pretty much all services exposed by the SDK. Having a common framework can significantly reduce the code duplication (in fact I started working on this after spending sometime on implementing error handling for `FirebaseAuth` and realizing how much it had common with `FirebaseMessaging`).
2. Typesafety via generics: Each service can now give a compile-time guarantee of the exception types they raise.