### PR TITLE
feat(fcm): Added the SubscribtToTopicAsync() and UnsubscribeFromTopicAsync() APIs

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
@@ -125,7 +125,8 @@ namespace FirebaseAdmin.IntegrationTests
         [Fact]
         public async Task SubscribeToTopic()
         {
-            var response = await FirebaseMessaging.DefaultInstance.SubscribeToTopicAsync("test-topic", new List<string> { "token1", "token2" });
+            var response = await FirebaseMessaging.DefaultInstance.SubscribeToTopicAsync(
+                new List<string> { "token1", "token2" }, "test-topic");
             Assert.NotNull(response);
             Assert.Equal(2, response.FailureCount);
             Assert.Equal("invalid-argument", response.Errors[0].Reason);
@@ -137,7 +138,8 @@ namespace FirebaseAdmin.IntegrationTests
         [Fact]
         public async Task UnsubscribeFromTopic()
         {
-            var response = await FirebaseMessaging.DefaultInstance.UnsubscribeFromTopicAsync("test-topic", new List<string> { "token1", "token2" });
+            var response = await FirebaseMessaging.DefaultInstance.UnsubscribeFromTopicAsync(
+                new List<string> { "token1", "token2" }, "test-topic");
             Assert.NotNull(response);
             Assert.Equal(2, response.FailureCount);
             Assert.Equal("invalid-argument", response.Errors[0].Reason);

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseMessagingSnippets.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseMessagingSnippets.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using FirebaseAdmin.Messaging;
 
@@ -320,6 +319,48 @@ namespace FirebaseAdmin.Snippets
             };
             // [END multi_platforms_message]
             return message;
+        }
+
+        internal static async Task SubscribeToTopicAsync(string topic)
+        {
+            // [START subscribe_to_topic]
+            // These registration tokens come from the client FCM SDKs.
+            var registrationTokens = new List<string>()
+            {
+                "YOUR_REGISTRATION_TOKEN_1",
+                // ...
+                "YOUR_REGISTRATION_TOKEN_n",
+            };
+
+            // Subscribe the devices corresponding to the registration tokens to the
+            // topic
+            var response = await FirebaseMessaging.DefaultInstance.SubscribeToTopicAsync(
+                registrationTokens, topic);
+            // See the TopicManagementResponse reference documentation
+            // for the contents of response.
+            Console.WriteLine($"{response.SuccessCount} tokens were subscribed successfully");
+            // [END subscribe_to_topic]
+        }
+
+        internal static async Task UnsubscribeFromTopicAsync(string topic)
+        {
+            // [START unsubscribe_from_topic]
+            // These registration tokens come from the client FCM SDKs.
+            var registrationTokens = new List<string>()
+            {
+                "YOUR_REGISTRATION_TOKEN_1",
+                // ...
+                "YOUR_REGISTRATION_TOKEN_n",
+            };
+
+            // Unsubscribe the devices corresponding to the registration tokens from the
+            // topic
+            var response = await FirebaseMessaging.DefaultInstance.UnsubscribeFromTopicAsync(
+                registrationTokens, topic);
+            // See the TopicManagementResponse reference documentation
+            // for the contents of response.
+            Console.WriteLine($"{response.SuccessCount} tokens were unsubscribed successfully");
+            // [END unsubscribe_from_topic]
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingTest.cs
@@ -138,7 +138,7 @@ namespace FirebaseAdmin.Messaging.Tests
             Assert.NotNull(messaging);
             Assert.Same(messaging, FirebaseMessaging.GetMessaging(app));
 
-            var response = await messaging.SubscribeToTopicAsync("test-topic", new List<string> { "test-token" });
+            var response = await messaging.SubscribeToTopicAsync(new List<string> { "test-token" }, "test-topic");
             Assert.Equal(0, response.FailureCount);
             Assert.Equal(1, response.SuccessCount);
             app.Delete();
@@ -163,7 +163,7 @@ namespace FirebaseAdmin.Messaging.Tests
             Assert.NotNull(messaging);
             Assert.Same(messaging, FirebaseMessaging.GetMessaging(app));
 
-            var response = await messaging.UnsubscribeFromTopicAsync("test-topic", new List<string> { "test-token" });
+            var response = await messaging.UnsubscribeFromTopicAsync(new List<string> { "test-token" }, "test-topic");
             Assert.Equal(0, response.FailureCount);
             Assert.Equal(1, response.SuccessCount);
             app.Delete();

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/InstanceIdClientTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/InstanceIdClientTest.cs
@@ -41,7 +41,7 @@ namespace FirebaseAdmin.Tests.Messaging
 
             var client = new InstanceIdClient(factory, MockCredential);
 
-            var result = await client.SubscribeToTopicAsync("test-topic", new List<string> { "abc123" });
+            var result = await client.SubscribeToTopicAsync(new List<string> { "abc123" }, "test-topic");
 
             Assert.Equal(1, result.SuccessCount);
         }
@@ -57,7 +57,7 @@ namespace FirebaseAdmin.Tests.Messaging
 
             var client = new InstanceIdClient(factory, MockCredential);
 
-            var result = await client.UnsubscribeFromTopicAsync("test-topic", new List<string> { "abc123" });
+            var result = await client.UnsubscribeFromTopicAsync(new List<string> { "abc123" }, "test-topic");
 
             Assert.Equal(1, result.SuccessCount);
         }
@@ -75,7 +75,7 @@ namespace FirebaseAdmin.Tests.Messaging
             var client = new InstanceIdClient(factory, MockCredential);
 
             var exception = await Assert.ThrowsAsync<FirebaseMessagingException>(
-               () => client.SubscribeToTopicAsync("test-topic", new List<string> { "abc123" }));
+               () => client.SubscribeToTopicAsync(new List<string> { "abc123" }, "test-topic"));
 
             Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
             Assert.Equal("Unexpected HTTP response with status: 400 (BadRequest)\nBadRequest", exception.Message);
@@ -97,7 +97,7 @@ namespace FirebaseAdmin.Tests.Messaging
             var client = new InstanceIdClient(factory, MockCredential);
 
             var exception = await Assert.ThrowsAsync<FirebaseMessagingException>(
-               () => client.SubscribeToTopicAsync("test-topic", new List<string> { "abc123" }));
+               () => client.SubscribeToTopicAsync(new List<string> { "abc123" }, "test-topic"));
 
             Assert.Equal(ErrorCode.Unauthenticated, exception.ErrorCode);
             Assert.Equal("Unexpected HTTP response with status: 401 (Unauthorized)\nUnauthorized", exception.Message);
@@ -119,7 +119,7 @@ namespace FirebaseAdmin.Tests.Messaging
             var client = new InstanceIdClient(factory, MockCredential);
 
             var exception = await Assert.ThrowsAsync<FirebaseMessagingException>(
-               () => client.SubscribeToTopicAsync("test-topic", new List<string> { "abc123" }));
+               () => client.SubscribeToTopicAsync(new List<string> { "abc123" }, "test-topic"));
 
             Assert.Equal(ErrorCode.PermissionDenied, exception.ErrorCode);
             Assert.Equal("Unexpected HTTP response with status: 403 (Forbidden)\nForbidden", exception.Message);
@@ -141,7 +141,7 @@ namespace FirebaseAdmin.Tests.Messaging
             var client = new InstanceIdClient(factory, MockCredential);
 
             var exception = await Assert.ThrowsAsync<FirebaseMessagingException>(
-               () => client.SubscribeToTopicAsync("test-topic", new List<string> { "abc123" }));
+               () => client.SubscribeToTopicAsync(new List<string> { "abc123" }, "test-topic"));
 
             Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
             Assert.Equal("Unexpected HTTP response with status: 404 (NotFound)\nNotFound", exception.Message);
@@ -163,7 +163,7 @@ namespace FirebaseAdmin.Tests.Messaging
             var client = new InstanceIdClient(factory, MockCredential);
 
             var exception = await Assert.ThrowsAsync<FirebaseMessagingException>(
-               () => client.SubscribeToTopicAsync("test-topic", new List<string> { "abc123" }));
+               () => client.SubscribeToTopicAsync(new List<string> { "abc123" }, "test-topic"));
 
             Assert.Equal(ErrorCode.Unavailable, exception.ErrorCode);
             Assert.Equal("Unexpected HTTP response with status: 503 (ServiceUnavailable)\nServiceUnavailable", exception.Message);

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
@@ -315,23 +315,25 @@ namespace FirebaseAdmin.Messaging
         /// <summary>
         /// Subscribes a list of registration tokens to a topic.
         /// </summary>
-        /// <param name="topic">The topic name to subscribe to. /topics/ will be prepended to the topic name provided if absent.</param>
         /// <param name="registrationTokens">A list of registration tokens to subscribe.</param>
+        /// <param name="topic">The topic name to subscribe to. /topics/ will be prepended to the topic name provided if absent.</param>
         /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving details about the topic subscription operations.</returns>
-        public async Task<TopicManagementResponse> SubscribeToTopicAsync(string topic, List<string> registrationTokens)
+        public async Task<TopicManagementResponse> SubscribeToTopicAsync(
+            IReadOnlyList<string> registrationTokens, string topic)
         {
-            return await this.instanceIdClient.SubscribeToTopicAsync(topic, registrationTokens);
+            return await this.instanceIdClient.SubscribeToTopicAsync(registrationTokens, topic);
         }
 
         /// <summary>
         /// Unsubscribes a list of registration tokens from a topic.
         /// </summary>
-        /// <param name="topic">The topic name to unsubscribe from. /topics/ will be prepended to the topic name provided if absent.</param>
         /// <param name="registrationTokens">A list of registration tokens to unsubscribe.</param>
+        /// <param name="topic">The topic name to unsubscribe from. /topics/ will be prepended to the topic name provided if absent.</param>
         /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving details about the topic unsubscription operations.</returns>
-        public async Task<TopicManagementResponse> UnsubscribeFromTopicAsync(string topic, List<string> registrationTokens)
+        public async Task<TopicManagementResponse> UnsubscribeFromTopicAsync(
+            IReadOnlyList<string> registrationTokens, string topic)
         {
-            return await this.instanceIdClient.UnsubscribeFromTopicAsync(topic, registrationTokens);
+            return await this.instanceIdClient.UnsubscribeFromTopicAsync(registrationTokens, topic);
         }
 
         /// <summary>

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/InstanceIdClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/InstanceIdClient.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FirebaseAdmin.Util;
@@ -61,30 +60,30 @@ namespace FirebaseAdmin.Messaging
         /// <summary>
         /// Subscribes a list of registration tokens to a topic.
         /// </summary>
+        /// <param name="registrationTokens">A list of registration tokens to subscribe.</param>
         /// <param name="topic">The topic name to subscribe to. /topics/ will be prepended to the
         /// topic name provided if absent.</param>
-        /// <param name="registrationTokens">A list of registration tokens to subscribe.</param>
         /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving
         /// details about the topic subscription operations.</returns>
         public async Task<TopicManagementResponse> SubscribeToTopicAsync(
-            string topic, List<string> registrationTokens)
+            IReadOnlyList<string> registrationTokens, string topic)
         {
-            return await this.SendInstanceIdRequest(topic, registrationTokens, IidSubscriberPath)
+            return await this.SendInstanceIdRequest(registrationTokens, topic, IidSubscriberPath)
                 .ConfigureAwait(false);
         }
 
         /// <summary>
         /// Unsubscribes a list of registration tokens from a topic.
         /// </summary>
+        /// <param name="registrationTokens">A list of registration tokens to unsubscribe.</param>
         /// <param name="topic">The topic name to unsubscribe from. /topics/ will be prepended to
         /// the topic name provided if absent.</param>
-        /// <param name="registrationTokens">A list of registration tokens to unsubscribe.</param>
         /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving
         /// details about the topic unsubscription operations.</returns>
         public async Task<TopicManagementResponse> UnsubscribeFromTopicAsync(
-            string topic, List<string> registrationTokens)
+            IReadOnlyList<string> registrationTokens, string topic)
         {
-            return await this.SendInstanceIdRequest(topic, registrationTokens, IidUnsubscribePath)
+            return await this.SendInstanceIdRequest(registrationTokens, topic, IidUnsubscribePath)
                 .ConfigureAwait(false);
         }
 
@@ -97,7 +96,7 @@ namespace FirebaseAdmin.Messaging
         }
 
         private async Task<TopicManagementResponse> SendInstanceIdRequest(
-            string topic, List<string> registrationTokens, string path)
+            IReadOnlyList<string> registrationTokens, string topic, string path)
         {
             this.ValidateRegistrationTokenList(registrationTokens);
 
@@ -123,21 +122,22 @@ namespace FirebaseAdmin.Messaging
             return new TopicManagementResponse(response.Result);
         }
 
-        private void ValidateRegistrationTokenList(List<string> registrationTokens)
+        private void ValidateRegistrationTokenList(IReadOnlyList<string> registrationTokens)
         {
             if (registrationTokens == null)
             {
-                throw new ArgumentNullException("Registration token list must not be null");
+                throw new ArgumentNullException("Registration tokens list must not be null");
             }
 
-            if (registrationTokens.Count() == 0)
+            var count = registrationTokens.Count;
+            if (count == 0)
             {
-                throw new ArgumentException("Registration token list must not be empty");
+                throw new ArgumentException("Registration tokens list must not be empty");
             }
 
-            if (registrationTokens.Count() > 1000)
+            if (count > 1000)
             {
-                throw new ArgumentException("Registration token list must not contain more than 1000 tokens");
+                throw new ArgumentException("Registration tokens list must not contain more than 1000 tokens");
             }
 
             foreach (var registrationToken in registrationTokens)
@@ -167,7 +167,7 @@ namespace FirebaseAdmin.Messaging
             public string Topic { get; set; }
 
             [JsonProperty("registration_tokens")]
-            public List<string> RegistrationTokens { get; set; }
+            public IEnumerable<string> RegistrationTokens { get; set; }
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/InstanceIdClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/InstanceIdClient.cs
@@ -126,18 +126,18 @@ namespace FirebaseAdmin.Messaging
         {
             if (registrationTokens == null)
             {
-                throw new ArgumentNullException("Registration tokens list must not be null");
+                throw new ArgumentNullException("Registration token list must not be null");
             }
 
             var count = registrationTokens.Count;
             if (count == 0)
             {
-                throw new ArgumentException("Registration tokens list must not be empty");
+                throw new ArgumentException("Registration token list must not be empty");
             }
 
             if (count > 1000)
             {
-                throw new ArgumentException("Registration tokens list must not contain more than 1000 tokens");
+                throw new ArgumentException("Registration token list must not contain more than 1000 tokens");
             }
 
             foreach (var registrationToken in registrationTokens)

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/InstanceIdServiceResponse.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/InstanceIdServiceResponse.cs
@@ -6,7 +6,8 @@ namespace FirebaseAdmin.Messaging
 {
     /// <summary>
     /// Response from an operation that subscribes or unsubscribes registration tokens to a topic.
-    /// See <see cref="FirebaseMessaging.SubscribeToTopicAsync(string, List{string})"/> and <see cref="FirebaseMessaging.UnsubscribeFromTopicAsync(string, List{string})"/>.
+    /// See <see cref="FirebaseMessaging.SubscribeToTopicAsync(IReadOnlyList{string}, string)"/> and
+    /// <see cref="FirebaseMessaging.UnsubscribeFromTopicAsync(IReadOnlyList{string}, string)"/>.
     /// </summary>
     internal class InstanceIdServiceResponse
     {


### PR DESCRIPTION
1. Changing the public API to meet the approved design spec (go/dotnet-fcm)
2. Added snippets to appear in https://firebase.google.com/docs/cloud-messaging/manage-topics