### PR TITLE
feat(auth): Migrating CreateCustomTokenAsync() APIs to the new error handling scheme

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -20,8 +20,6 @@ using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
-using FirebaseAdmin.Auth;
-using Google.Apis.Auth;
 using Google.Apis.Auth.OAuth2;
 using Xunit;
 
@@ -114,8 +112,15 @@ namespace FirebaseAdmin.Auth.Tests
         public async Task CreateCustomTokenInvalidCredential()
         {
             FirebaseApp.Create(new AppOptions() { Credential = MockCredential });
-            await Assert.ThrowsAsync<FirebaseException>(
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
                 async () => await FirebaseAuth.DefaultInstance.CreateCustomTokenAsync("user1"));
+
+            var errorMessage = "Failed to determine service account ID. Make sure to initialize the SDK "
+                + "with service account credentials or specify a service account "
+                + "ID with iam.serviceAccounts.signBlob permission. Please refer to "
+                + "https://firebase.google.com/docs/auth/admin/create-custom-tokens for "
+                + "more details on creating custom tokens.";
+            Assert.Equal(errorMessage, ex.Message);
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
@@ -105,7 +105,9 @@ namespace FirebaseAdmin.Auth
         /// <returns>A task that completes with a Firebase custom token.</returns>
         /// <exception cref="ArgumentException">If <paramref name="uid"/> is null, empty or longer
         /// than 128 characters.</exception>
-        /// <exception cref="FirebaseException">If an error occurs while creating a custom
+        /// <exception cref="InvalidOperationException">If no service account can be discovered
+        /// from either the <see cref="AppOptions"/> or the deployment environment.</exception>
+        /// <exception cref="FirebaseAuthException">If an error occurs while creating a custom
         /// token.</exception>
         /// <param name="uid">The UID to store in the token. This identifies the user to other
         /// Firebase services (Realtime Database, Firebase Auth, etc.). Must not be longer than
@@ -141,7 +143,9 @@ namespace FirebaseAdmin.Auth
         /// <returns>A task that completes with a Firebase custom token.</returns>
         /// <exception cref="ArgumentException">If <paramref name="uid"/> is null, empty or longer
         /// than 128 characters.</exception>
-        /// <exception cref="FirebaseException">If an error occurs while creating a custom
+        /// <exception cref="InvalidOperationException">If no service account can be discovered
+        /// from either the <see cref="AppOptions"/> or the deployment environment.</exception>
+        /// <exception cref="FirebaseAuthException">If an error occurs while creating a custom
         /// token.</exception>
         /// <param name="uid">The UID to store in the token. This identifies the user to other
         /// Firebase services (Realtime Database, Firebase Auth, etc.). Must not be longer than
@@ -167,7 +171,9 @@ namespace FirebaseAdmin.Auth
         /// <exception cref="ArgumentException">If <paramref name="uid"/> is null, empty or longer
         /// than 128 characters. Or, if <paramref name="developerClaims"/> contains any standard
         /// JWT claims.</exception>
-        /// <exception cref="FirebaseException">If an error occurs while creating a custom
+        /// <exception cref="InvalidOperationException">If no service account can be discovered
+        /// from either the <see cref="AppOptions"/> or the deployment environment.</exception>
+        /// <exception cref="FirebaseAuthException">If an error occurs while creating a custom
         /// token.</exception>
         /// <param name="uid">The UID to store in the token. This identifies the user to other
         /// Firebase services (Realtime Database, Firebase Auth, etc.). Must not be longer than
@@ -194,7 +200,9 @@ namespace FirebaseAdmin.Auth
         /// <exception cref="ArgumentException">If <paramref name="uid"/> is null, empty or longer
         /// than 128 characters. Or, if <paramref name="developerClaims"/> contains any standard
         /// JWT claims.</exception>
-        /// <exception cref="FirebaseException">If an error occurs while creating a custom
+        /// <exception cref="InvalidOperationException">If no service account can be discovered
+        /// from either the <see cref="AppOptions"/> or the deployment environment.</exception>
+        /// <exception cref="FirebaseAuthException">If an error occurs while creating a custom
         /// token.</exception>
         /// <param name="uid">The UID to store in the token. This identifies the user to other
         /// Firebase services (Realtime Database, Firebase Auth, etc.). Must not be longer than

--- a/FirebaseAdmin/FirebaseAdmin/FirebaseException.cs
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseException.cs
@@ -22,12 +22,6 @@ namespace FirebaseAdmin
     /// </summary>
     public class FirebaseException : Exception
     {
-        internal FirebaseException(string message)
-        : base(message) { } // TODO: Remove this constructor
-
-        internal FirebaseException(string message, Exception inner)
-        : base(message, inner) { } // TODO: Remove this constructor
-
         internal FirebaseException(
             ErrorCode code,
             string message,
@@ -42,8 +36,12 @@ namespace FirebaseAdmin
         /// <summary>
         /// Gets the platform-wide error code associated with this exception.
         /// </summary>
-        internal ErrorCode ErrorCode { get; private set; } // TODO: Expose this as public
+        public ErrorCode ErrorCode { get; private set; }
 
-        internal HttpResponseMessage HttpResponse { get; private set; }
+        /// <summary>
+        /// Gets the HTTP response that resulted in this exception. Null, if the exception was not
+        /// caused by an HTTP error response.
+        /// </summary>
+        public HttpResponseMessage HttpResponse { get; private set; }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushNotification.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushNotification.cs
@@ -164,7 +164,7 @@ namespace FirebaseAdmin.Messaging
                         this.Direction = Messaging.Direction.RightToLeft;
                         return;
                     default:
-                        throw new FirebaseException(
+                        throw new ArgumentException(
                             $"Invalid direction value: {value}. Only 'auto', 'rtl' and 'ltr' "
                             + "are allowed.");
                 }


### PR DESCRIPTION
* Throwing `FirebaseAuthException` from the custom token creation APIs.
* Throwing `InvalidOperationException` when the service account ID is not set up (this is not an exception that we expect developers to "handle" at runtime, and therefore should not raise a `FirebaseException`)
* Exposed `ErrorCode` from the parent `FirebaseException` class.

This completes the error handling revamp for the .NET Admin SDK.

RELEASE NOTES: `CreateCustomTokenAsync()` API now throws `FirebaseAuthException` if an error occurs while signing custom tokens. If the service account is not correctly configured, this API throws an `InvalidOperationException`.