### PR TITLE
Requesting detailed error responses from FCM backend

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessagingClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessagingClient.cs
@@ -174,6 +174,7 @@ namespace FirebaseAdmin.Messaging
         private static void AddCommonHeaders(HttpRequestMessage request)
         {
             request.Headers.Add("X-Firebase-Client", ClientVersion);
+            request.Headers.Add("X-GOOG-API-FORMAT-VERSION", "2");
         }
 
         private async Task<BatchResponse> SendBatchRequestAsync(


### PR DESCRIPTION
Set the `X-GOOG-API-FORMAT-VERSION` header on FCM requests.

Partly related to #45.