### PR TITLE
feat(fcm): Add image in notification support

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
@@ -38,6 +38,7 @@ namespace FirebaseAdmin.IntegrationTests
                 {
                     Title = "Title",
                     Body = "Body",
+                    ImageUrl = "https://example.com/image.png",
                 },
                 Android = new AndroidConfig()
                 {
@@ -61,6 +62,7 @@ namespace FirebaseAdmin.IntegrationTests
                 {
                     Title = "Title",
                     Body = "Body",
+                    ImageUrl = "https://example.com/image.png",
                 },
                 Android = new AndroidConfig()
                 {

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -74,6 +74,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 {
                     Title = "title",
                     Body = "body",
+                    ImageUrl = "https://example.com/image.png",
                 },
                 FcmOptions = new FcmOptions()
                 {
@@ -88,6 +89,7 @@ namespace FirebaseAdmin.Messaging.Tests
                     {
                         { "title", "title" },
                         { "body", "body" },
+                        { "image", "https://example.com/image.png" },
                     }
                 },
                 {
@@ -220,6 +222,28 @@ namespace FirebaseAdmin.Messaging.Tests
         }
 
         [Fact]
+        public void NotificationInvalidImageUrls()
+        {
+            var imageUrls = new List<string>()
+            {
+                string.Empty, "image.png", "invalid-image", "foo bar",
+            };
+            foreach (var imageUrl in imageUrls)
+            {
+                var message = new Message()
+                {
+                    Topic = "test-topic",
+                    Notification = new Notification()
+                    {
+                        ImageUrl = imageUrl,
+                    },
+                };
+
+                Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+            }
+        }
+
+        [Fact]
         public void AndroidConfig()
         {
             var message = new Message()
@@ -244,6 +268,7 @@ namespace FirebaseAdmin.Messaging.Tests
                         Color = "#112233",
                         Sound = "sound",
                         Tag = "tag",
+                        ImageUrl = "https://example.com/image.png",
                         ClickAction = "click-action",
                         TitleLocKey = "title-loc-key",
                         TitleLocArgs = new List<string>() { "arg1", "arg2" },
@@ -277,6 +302,7 @@ namespace FirebaseAdmin.Messaging.Tests
                                 { "color", "#112233" },
                                 { "sound", "sound" },
                                 { "tag", "tag" },
+                                { "image", "https://example.com/image.png" },
                                 { "click_action", "click-action" },
                                 { "title_loc_key", "title-loc-key" },
                                 { "title_loc_args", new JArray() { "arg1", "arg2" } },
@@ -390,6 +416,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 Color = "#112233",
                 Sound = "sound",
                 Tag = "tag",
+                ImageUrl = "https://example.com/image.png",
                 ClickAction = "click-action",
                 TitleLocKey = "title-loc-key",
                 TitleLocArgs = new List<string>() { "arg1", "arg2" },
@@ -405,6 +432,7 @@ namespace FirebaseAdmin.Messaging.Tests
             Assert.Equal(original.Color, copy.Color);
             Assert.Equal(original.Sound, copy.Sound);
             Assert.Equal(original.Tag, copy.Tag);
+            Assert.Equal(original.ImageUrl, copy.ImageUrl);
             Assert.Equal(original.ClickAction, copy.ClickAction);
             Assert.Equal(original.TitleLocKey, copy.TitleLocKey);
             Assert.Equal(original.TitleLocArgs, copy.TitleLocArgs);
@@ -458,6 +486,30 @@ namespace FirebaseAdmin.Messaging.Tests
                 },
             };
             Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+        }
+
+        [Fact]
+        public void AndroidNotificationInvalidImageUrls()
+        {
+            var imageUrls = new List<string>()
+            {
+                string.Empty, "image.png", "invalid-image", "foo bar",
+            };
+            foreach (var imageUrl in imageUrls)
+            {
+                var message = new Message()
+                {
+                    Topic = "test-topic",
+                    Android = new AndroidConfig()
+                    {
+                        Notification = new AndroidNotification()
+                        {
+                            ImageUrl = imageUrl,
+                        },
+                    },
+                };
+                Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+            }
         }
 
         [Fact]
@@ -871,6 +923,7 @@ namespace FirebaseAdmin.Messaging.Tests
                     FcmOptions = new ApnsFcmOptions()
                     {
                         AnalyticsLabel = "label",
+                        ImageUrl = "https://example.com/image.png",
                     },
                 },
             };
@@ -912,6 +965,7 @@ namespace FirebaseAdmin.Messaging.Tests
                             "fcm_options", new JObject()
                             {
                                 { "analytics_label", "label" },
+                                { "image", "https://example.com/image.png" },
                             }
                         },
                     }
@@ -1591,6 +1645,30 @@ namespace FirebaseAdmin.Messaging.Tests
                 },
             };
             Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+        }
+
+        [Fact]
+        public void ApnsFcmOptionsInvalidImageUrls()
+        {
+            var imageUrls = new List<string>()
+            {
+                string.Empty, "image.png", "invalid-image", "foo bar",
+            };
+            foreach (var imageUrl in imageUrls)
+            {
+                var message = new Message()
+                {
+                    Topic = "test-topic",
+                    Apns = new ApnsConfig()
+                    {
+                        FcmOptions = new ApnsFcmOptions()
+                        {
+                            ImageUrl = imageUrl,
+                        },
+                    },
+                };
+                Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+            }
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
@@ -67,6 +67,12 @@ namespace FirebaseAdmin.Messaging
         public string Tag { get; set; }
 
         /// <summary>
+        /// Gets or sets the URL of the image to be displayed in the notification.
+        /// </summary>
+        [JsonProperty("image")]
+        public string ImageUrl { get; set; }
+
+        /// <summary>
         /// Gets or sets the action associated with a user click on the notification. If specified,
         /// an activity with a matching Intent Filter is launched when a user clicks on the
         /// notification.
@@ -126,6 +132,7 @@ namespace FirebaseAdmin.Messaging
                 Color = this.Color,
                 Sound = this.Sound,
                 Tag = this.Tag,
+                ImageUrl = this.ImageUrl,
                 ClickAction = this.ClickAction,
                 TitleLocKey = this.TitleLocKey,
                 TitleLocArgs = this.TitleLocArgs?.ToList(),
@@ -146,6 +153,11 @@ namespace FirebaseAdmin.Messaging
             if (copy.BodyLocArgs?.Any() == true && string.IsNullOrEmpty(copy.BodyLocKey))
             {
                 throw new ArgumentException("BodyLocKey is required when specifying BodyLocArgs.");
+            }
+
+            if (copy.ImageUrl != null && !Uri.IsWellFormedUriString(copy.ImageUrl, UriKind.Absolute))
+            {
+                throw new ArgumentException($"Malformed image URL string: {copy.ImageUrl}.");
             }
 
             return copy;

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/ApnsFcmOptions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/ApnsFcmOptions.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using FirebaseAdmin.Messaging.Util;
 using Newtonsoft.Json;
 
@@ -29,6 +30,12 @@ namespace FirebaseAdmin.Messaging
         public string AnalyticsLabel { get; set; }
 
         /// <summary>
+        /// Gets or sets the URL of the image to be displayed in the notification.
+        /// </summary>
+        [JsonProperty("image")]
+        public string ImageUrl { get; set; }
+
+        /// <summary>
         /// Copies this FCM options, and validates the content of it to ensure that it can
         /// be serialized into the JSON format expected by the FCM service.
         /// </summary>
@@ -37,8 +44,14 @@ namespace FirebaseAdmin.Messaging
             var copy = new ApnsFcmOptions()
             {
                 AnalyticsLabel = this.AnalyticsLabel,
+                ImageUrl = this.ImageUrl,
             };
             AnalyticsLabelChecker.ValidateAnalyticsLabel(copy.AnalyticsLabel);
+
+            if (copy.ImageUrl != null && !Uri.IsWellFormedUriString(copy.ImageUrl, UriKind.Absolute))
+            {
+                throw new ArgumentException($"Malformed image URL string: {copy.ImageUrl}.");
+            }
 
             return copy;
         }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/Notification.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/Notification.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Newtonsoft.Json;
 
 namespace FirebaseAdmin.Messaging
@@ -34,16 +35,30 @@ namespace FirebaseAdmin.Messaging
         public string Body { get; set; }
 
         /// <summary>
-        /// Copies this notification. There is nothing to be validated in this class, but we use
-        /// the same method name as in other classes in this namespace.
+        /// Gets or sets the URL of the image to be displayed in the notification.
+        /// </summary>
+        [JsonProperty("image")]
+        public string ImageUrl { get; set; }
+
+        /// <summary>
+        /// Copies this notification, and validates the content of it to ensure that it can
+        /// be serialized into the JSON format expected by the FCM service.
         /// </summary>
         internal Notification CopyAndValidate()
         {
-            return new Notification()
+            var copy = new Notification()
             {
                 Title = this.Title,
                 Body = this.Body,
+                ImageUrl = this.ImageUrl,
             };
+
+            if (copy.ImageUrl != null && !Uri.IsWellFormedUriString(copy.ImageUrl, UriKind.Absolute))
+            {
+                throw new ArgumentException($"Malformed image URL string: {copy.ImageUrl}.");
+            }
+
+            return copy;
         }
     }
 }


### PR DESCRIPTION
### Discussion

  * Add image in notification support

### Testing

  * Add unit tests and modified integration test to reflect this change

### API Changes

  * In Firebase Cloud Messaging, added 'image' field in the general Notification class, the AndroidNotification class, and the ApnsFcmOptions class.

RELEASE NOTE: Added new APIs for specifying an image URL in notifications.

Resolves #95 