### PR TITLE
Remove (base64) 'REDACTED' passwords from user records.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,8 +144,16 @@ test suite makes a large number of writes to the Firebase realtime database. Dow
 account key file from the "Settings > Service Accounts" page of the project, and copy it to
 `FirebaseAdmin/FirebaseAdmin.IntegrationTests/resources/integration_cert.json`. Also obtain the
 API key for the same project from "Settings > General", and save it to
-`FirebaseAdmin/FirebaseAdmin.IntegrationTests/resources/integration_apikey.txt`. Finally, to run
-the integration test suite:
+`FirebaseAdmin/FirebaseAdmin.IntegrationTests/resources/integration_apikey.txt`.
+
+You'll also need to grant your service account the 'Firebase Authentication Admin' role. This is
+required to ensure that exported user records contain the password hashes of the user accounts:
+1. Go to [Google Cloud Platform Console / IAM & admin](https://console.cloud.google.com/iam-admin).
+2. Find your service account in the list, and click the 'pencil' icon to edit it's permissions.
+3. Click 'ADD ANOTHER ROLE' and choose 'Firebase Authentication Admin'.
+4. Click 'SAVE'.
+
+Finally, to run the integration test suite:
 
 ```bash
 $ dotnet test FirebaseAdmin.IntegrationTests

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAuthTest.cs
@@ -324,8 +324,15 @@ namespace FirebaseAdmin.IntegrationTests
                     if (users.Contains(uid) && !listedUsers.Contains(uid))
                     {
                         listedUsers.Add(uid);
-                        Assert.NotNull(enumerator.Current.PasswordHash);
-                        Assert.NotNull(enumerator.Current.PasswordSalt);
+                        var errMsgTemplate = "Missing {0} field. A common cause would be "
+                            + "forgetting to add the 'Firebase Authentication Admin' permission. "
+                            + "See instructions in CONTRIBUTING.md";
+                        AssertWithMessage.NotNull(
+                            enumerator.Current.PasswordHash,
+                            errMsgTemplate.Format("PasswordHash"));
+                        AssertWithMessage.NotNull(
+                            enumerator.Current.PasswordSalt,
+                            errMsgTemplate.Format("PasswordSalt"));
                     }
                 }
 
@@ -406,6 +413,20 @@ namespace FirebaseAdmin.IntegrationTests
                 Email = email,
                 PhoneNumber = phone,
             };
+        }
+    }
+
+    /**
+     * Additional Xunit style asserts that allow specifying an error message upon failure.
+     */
+    internal class AssertWithMessage
+    {
+        internal static void NotNull(object obj, string msg)
+        {
+            if (obj == null)
+            {
+                throw new Xunit.Sdk.XunitException("Assert.NotNull() Failure: " + msg);
+            }
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAuthTest.cs
@@ -329,10 +329,10 @@ namespace FirebaseAdmin.IntegrationTests
                             + "See instructions in CONTRIBUTING.md";
                         AssertWithMessage.NotNull(
                             enumerator.Current.PasswordHash,
-                            errMsgTemplate.Format("PasswordHash"));
+                            string.Format(errMsgTemplate, "PasswordHash"));
                         AssertWithMessage.NotNull(
                             enumerator.Current.PasswordSalt,
-                            errMsgTemplate.Format("PasswordSalt"));
+                            string.Format(errMsgTemplate, "PasswordSalt"));
                     }
                 }
 

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAuthTest.cs
@@ -372,6 +372,20 @@ namespace FirebaseAdmin.IntegrationTests
         }
     }
 
+    /**
+     * Additional Xunit style asserts that allow specifying an error message upon failure.
+     */
+    internal static class AssertWithMessage
+    {
+        internal static void NotNull(object obj, string msg)
+        {
+            if (obj == null)
+            {
+                throw new Xunit.Sdk.XunitException("Assert.NotNull() Failure: " + msg);
+            }
+        }
+    }
+
     internal class SignInRequest
     {
         [Newtonsoft.Json.JsonProperty("token")]
@@ -413,20 +427,6 @@ namespace FirebaseAdmin.IntegrationTests
                 Email = email,
                 PhoneNumber = phone,
             };
-        }
-    }
-
-    /**
-     * Additional Xunit style asserts that allow specifying an error message upon failure.
-     */
-    internal class AssertWithMessage
-    {
-        internal static void NotNull(object obj, string msg)
-        {
-            if (obj == null)
-            {
-                throw new Xunit.Sdk.XunitException("Assert.NotNull() Failure: " + msg);
-            }
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/ExportedUserRecordTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/ExportedUserRecordTest.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Xunit;
 
 namespace FirebaseAdmin.Auth.Tests
@@ -158,8 +159,7 @@ namespace FirebaseAdmin.Auth.Tests
             var user = new ExportedUserRecord(new GetAccountInfoResponse.User()
             {
                 UserId = "user1",
-                PasswordHash = System.Convert.ToBase64String(
-                        System.Text.Encoding.UTF8.GetBytes("REDACTED")),
+                PasswordHash = Convert.ToBase64String(Encoding.UTF8.GetBytes("REDACTED")),
             });
 
             Assert.Null(user.PasswordHash);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/ExportedUserRecordTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/ExportedUserRecordTest.cs
@@ -151,5 +151,18 @@ namespace FirebaseAdmin.Auth.Tests
             Assert.Equal(UserRecord.UnixEpoch.AddMilliseconds(100), metadata.CreationTimestamp);
             Assert.Equal(UserRecord.UnixEpoch.AddMilliseconds(150), metadata.LastSignInTimestamp);
         }
+
+        [Fact]
+        public void RedactedPasswordCleared()
+        {
+            var user = new ExportedUserRecord(new GetAccountInfoResponse.User()
+            {
+                UserId = "user1",
+                PasswordHash = System.Convert.ToBase64String(
+                        System.Text.Encoding.UTF8.GetBytes("REDACTED")),
+            });
+
+            Assert.Null(user.PasswordHash);
+        }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/ExportedUserRecord.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/ExportedUserRecord.cs
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+using System.Text;
+
 namespace FirebaseAdmin.Auth
 {
     /// <summary>
@@ -21,7 +24,7 @@ namespace FirebaseAdmin.Auth
     public sealed class ExportedUserRecord : UserRecord
     {
         private static readonly string B64Redacted =
-            System.Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("REDACTED"));
+            Convert.ToBase64String(Encoding.UTF8.GetBytes("REDACTED"));
 
         internal ExportedUserRecord(GetAccountInfoResponse.User user)
             : base(user)

--- a/FirebaseAdmin/FirebaseAdmin/Auth/ExportedUserRecord.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/ExportedUserRecord.cs
@@ -20,10 +20,16 @@ namespace FirebaseAdmin.Auth
     /// </summary>
     public sealed class ExportedUserRecord : UserRecord
     {
+        private static readonly string B64Redacted =
+            System.Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("REDACTED"));
+
         internal ExportedUserRecord(GetAccountInfoResponse.User user)
             : base(user)
         {
-            this.PasswordHash = user.PasswordHash;
+            // If the password hash is redacted (probably due to missing permissions) then clear it
+            // out, similar to how the salt is returned. (Otherwise, it *looks* like a b64-encoded
+            // hash is present, which is confusing.)
+            this.PasswordHash = user.PasswordHash == B64Redacted ? null : user.PasswordHash;
             this.PasswordSalt = user.PasswordSalt;
         }
 


### PR DESCRIPTION
These values *look* like password hashes, but aren't, leading to
potential confusion.

Additionally, added docs to CONTRIBUTING.md detailing how to add the
permission that causes password hashes to be properly returned as well
as adjusting the test failure message should the developer not add that
permission.

b/141189502