### PR TITLE
fix(auth): Added EMAIL_EXISTS Auth error message.

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthErrorHandlerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthErrorHandlerTest.cs
@@ -41,6 +41,12 @@ namespace FirebaseAdmin.Auth.Tests
                 },
                 new object[]
                 {
+                    "EMAIL_EXISTS",
+                    ErrorCode.AlreadyExists,
+                    AuthErrorCode.EmailAlreadyExists,
+                },
+                new object[]
+                {
                     "PHONE_NUMBER_EXISTS",
                     ErrorCode.AlreadyExists,
                     AuthErrorCode.PhoneNumberAlreadyExists,

--- a/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorHandler.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorHandler.cs
@@ -50,6 +50,13 @@ namespace FirebaseAdmin.Auth
                         "The user with the provided uid already exists")
                 },
                 {
+                    "EMAIL_EXISTS",
+                    new ErrorInfo(
+                        ErrorCode.AlreadyExists,
+                        AuthErrorCode.EmailAlreadyExists,
+                        "The user with the provided email already exists")
+                },
+                {
                     "PHONE_NUMBER_EXISTS",
                     new ErrorInfo(
                         ErrorCode.AlreadyExists,


### PR DESCRIPTION
Added missing EMAIL_EXISTS Auth error message.
Not sure if the DUPLICATE_EMAIL message is already deprecated, as firebase api documentation is not clear about this for me.

RELEASE NOTE: User management APIs now correctly raise `ErrorCode.AlreadyExists` when an already in-use email address is specified for a user.