### PR TITLE
chore: Implementing the publish workflow

### DIFF
--- a/.github/scripts/generate_changelog.sh
+++ b/.github/scripts/generate_changelog.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -e
+set -u
+
+function printChangelog() {
+  local TITLE=$1
+  shift
+  # Skip the sentinel value.
+  local ENTRIES=("${@:2}")
+  if [ ${#ENTRIES[@]} -ne 0 ]; then
+    echo "### ${TITLE}"
+    echo ""
+    for ((i = 0; i < ${#ENTRIES[@]}; i++))
+    do
+        echo "* ${ENTRIES[$i]}"
+    done
+    echo ""
+  fi
+}
+
+if [[ -z "${GITHUB_SHA}" ]]; then
+  GITHUB_SHA="HEAD"
+fi
+
+LAST_TAG=`git describe --tags $(git rev-list --tags --max-count=1) 2> /dev/null` || true
+if [[ -z "${LAST_TAG}" ]]; then
+  echo "[INFO] No tags found. Including all commits up to ${GITHUB_SHA}."
+  VERSION_RANGE="${GITHUB_SHA}"
+else
+  echo "[INFO] Last release tag: ${LAST_TAG}."
+  COMMIT_SHA=`git show-ref -s ${LAST_TAG}`
+  echo "[INFO] Last release commit: ${COMMIT_SHA}."
+  VERSION_RANGE="${COMMIT_SHA}..${GITHUB_SHA}"
+  echo "[INFO] Including all commits in the range ${VERSION_RANGE}."
+fi
+
+echo ""
+
+# Older versions of Bash (< 4.4) treat empty arrays as unbound variables, which triggers
+# errors when referencing them. Therefore we initialize each of these arrays with an empty
+# sentinel value, and later skip them.
+CHANGES=("")
+FIXES=("")
+FEATS=("")
+MISC=("")
+
+while read -r line
+do
+  COMMIT_MSG=`echo ${line} | cut -d ' ' -f 2-`
+  if [[ $COMMIT_MSG =~ ^change(\(.*\))?: ]]; then
+    CHANGES+=("$COMMIT_MSG")
+  elif [[ $COMMIT_MSG =~ ^fix(\(.*\))?: ]]; then
+    FIXES+=("$COMMIT_MSG")
+  elif [[ $COMMIT_MSG =~ ^feat(\(.*\))?: ]]; then
+    FEATS+=("$COMMIT_MSG")
+  else
+    MISC+=("${COMMIT_MSG}")
+  fi
+done < <(git log ${VERSION_RANGE} --oneline)
+
+printChangelog "Breaking Changes" "${CHANGES[@]}"
+printChangelog "New Features" "${FEATS[@]}"
+printChangelog "Bug Fixes" "${FIXES[@]}"
+printChangelog "Miscellaneous" "${MISC[@]}"

--- a/.github/scripts/publish_package.sh
+++ b/.github/scripts/publish_package.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+set -u
+
+readonly UNPREFIXED_VERSION=`echo ${VERSION} | cut -c 2-`
+dotnet nuget push Release/FirebaseAdmin.${UNPREFIXED_VERSION}.nupkg \
+  -k ${NUGET_KEY} \
+  -s https://api.nuget.org/v3/index.json

--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+
+# Copyright 2020 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+###################################### Outputs #####################################
+
+# 1. version: The version of this release including the 'v' prefix (e.g. v1.2.3).
+# 2. changelog: Formatted changelog text for this release.
+
+####################################################################################
+
+set -e
+set -u
+
+function echo_info() {
+    local MESSAGE=$1
+    echo "[INFO] ${MESSAGE}"
+}
+
+function echo_warn() {
+    local MESSAGE=$1
+    echo "[WARN] ${MESSAGE}"
+}
+
+function terminate() {
+    echo ""
+    echo_warn "--------------------------------------------"
+    echo_warn "PREFLIGHT FAILED"
+    echo_warn "--------------------------------------------"
+    exit 1
+}
+
+
+echo_info "Starting publish preflight check..."
+echo_info "Git revision          : ${GITHUB_SHA}"
+echo_info "Workflow triggered by : ${GITHUB_ACTOR}"
+echo_info "GitHub event          : ${GITHUB_EVENT_NAME}"
+
+
+echo_info ""
+echo_info "--------------------------------------------"
+echo_info "Extracting release version"
+echo_info "--------------------------------------------"
+echo_info ""
+
+readonly PROJECT_FILE="FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj"
+echo_info "Loading version from: ${PROJECT_FILE}"
+
+readonly RELEASE_VERSION=`grep -oPm1 "(?<=<Version>)[^<]+" ${PROJECT_FILE}` || true
+if [[ -z "${RELEASE_VERSION}" ]]; then
+  echo_warn "Failed to extract release version from: ${PROJECT_FILE}"
+  terminate
+fi
+
+if [[ ! "${RELEASE_VERSION}" =~ ^([0-9]*)\.([0-9]*)\.([0-9]*)$ ]]; then
+  echo_warn "Malformed release version string: ${RELEASE_VERSION}. Exiting."
+  terminate
+fi
+
+echo_info "Extracted release version: ${RELEASE_VERSION}"
+echo "::set-output name=version::v${RELEASE_VERSION}"
+
+
+echo_info ""
+echo_info "--------------------------------------------"
+echo_info "Check release artifacts"
+echo_info "--------------------------------------------"
+echo_info ""
+
+if [[ ! -d Release ]]; then
+  echo_warn "Release directory does not exist."
+  terminate
+fi
+
+readonly RELEASE_ARTIFACT="Release/FirebaseAdmin.${RELEASE_VERSION}.nupkg"
+if [[ -f "${RELEASE_ARTIFACT}" ]]; then
+  echo_info "Found release artifact: ${RELEASE_ARTIFACT}"
+else
+  echo_warn "Release artifact ${RELEASE_ARTIFACT} not found."
+  terminate
+fi
+
+
+echo_info ""
+echo_info "--------------------------------------------"
+echo_info "Checking previous releases"
+echo_info "--------------------------------------------"
+echo_info ""
+
+
+mkdir -p VersionCheck
+pushd VersionCheck
+dotnet new console
+dotnet add package FirebaseAdmin --version ${RELEASE_VERSION} || true
+readonly PACKAGE_REFERENCE=`grep "PackageReference Include=\"FirebaseAdmin\"" VersionCheck.csproj` || true
+if [[ -n ${PACKAGE_REFERENCE} ]]; then
+  echo_warn "Release version ${RELEASE_VERSION} already present in Nuget."
+  terminate
+fi
+
+echo_info "Release version ${RELEASE_VERSION} not found in Nuget."
+popd
+
+
+echo_info ""
+echo_info "--------------------------------------------"
+echo_info "Checking release tag"
+echo_info "--------------------------------------------"
+echo_info ""
+
+echo_info "---< git fetch --depth=1 origin +refs/tags/*:refs/tags/* >---"
+git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+echo ""
+
+readonly EXISTING_TAG=`git rev-parse -q --verify "refs/tags/v${RELEASE_VERSION}"` || true
+if [[ -n "${EXISTING_TAG}" ]]; then
+  echo_warn "Tag v${RELEASE_VERSION} already exists. Exiting."
+  echo_warn "If the tag was created in a previous unsuccessful attempt, delete it and try again."
+  echo_warn "  $ git tag -d v${RELEASE_VERSION}"
+  echo_warn "  $ git push --delete origin v${RELEASE_VERSION}"
+
+  readonly RELEASE_URL="https://github.com/firebase/firebase-admin-dotnet/releases/tag/v${RELEASE_VERSION}"
+  echo_warn "Delete any corresponding releases at ${RELEASE_URL}."
+  terminate
+fi
+
+echo_info "Tag v${RELEASE_VERSION} does not exist."
+
+
+echo_info ""
+echo_info "--------------------------------------------"
+echo_info "Generating changelog"
+echo_info "--------------------------------------------"
+echo_info ""
+
+echo_info "---< git fetch origin master --prune --unshallow >---"
+git fetch origin master --prune --unshallow
+echo ""
+
+echo_info "Generating changelog from history..."
+readonly CURRENT_DIR=$(dirname "$0")
+readonly CHANGELOG=`${CURRENT_DIR}/generate_changelog.sh`
+echo "$CHANGELOG"
+
+# Parse and preformat the text to handle multi-line output.
+# See https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870
+FILTERED_CHANGELOG=`echo "$CHANGELOG" | grep -v "\\[INFO\\]"` || true
+FILTERED_CHANGELOG="${FILTERED_CHANGELOG//'%'/'%25'}"
+FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\n'/'%0A'}"
+FILTERED_CHANGELOG="${FILTERED_CHANGELOG//$'\r'/'%0D'}"
+echo "::set-output name=changelog::${FILTERED_CHANGELOG}"
+
+
+echo ""
+echo_info "--------------------------------------------"
+echo_info "PREFLIGHT SUCCESSFUL"
+echo_info "--------------------------------------------"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,7 +133,7 @@ jobs:
     - name: Post to Twitter
       if: success() &&
         contains(github.event.pull_request.labels.*.name, 'release:tweet')
-      uses: firebase/firebase-admin-node/.github/actions/send-tweet
+      uses: firebase/firebase-admin-node/.github/actions/send-tweet@master
       with:
         status: >
           ${{ steps.preflight.outputs.version }} of @Firebase Admin .NET SDK is avaialble.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       (github.event.pull_request.merged &&
         contains(github.event.pull_request.labels.*.name, 'release:publish'))
 
+    # Build and package artifacts on Windows.
     runs-on: windows-latest
 
     env:
@@ -70,3 +71,75 @@ jobs:
       with:
         name: Release
         path: FirebaseAdmin/FirebaseAdmin/bin/Release
+
+  publish_release:
+    needs: stage_release
+
+    # Check whether the release should be published. We publish only when the trigger PR is
+    #   1. merged
+    #   2. to the master branch
+    #   3. with the label 'release:publish', and
+    #   4. the title prefix '[chore] Release '.
+    if: github.event.pull_request.merged &&
+      github.ref == 'master' &&
+      contains(github.event.pull_request.labels.*.name, 'release:publish') &&
+      startsWith(github.event.pull_request.title, '[chore] Release ')
+
+    # Use Linux for this phase, so we can reuse the same helper scripts as other Admin SDK
+    # repositories.
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout source for publish
+      uses: actions/checkout@v2
+
+    # Download the artifacts created by the stage_release job.
+    - name: Download release candidates
+      uses: actions/download-artifact@v1
+      with:
+        name: Release
+
+    - name: Setup .NET Core
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.2.108
+
+    - name: Publish preflight check
+      id: preflight
+      run: ./.github/scripts/publish_preflight_check.sh
+
+    # We pull this action from a custom fork of a contributor until
+    # https://github.com/actions/create-release/pull/32 is merged. Also note that v1 of
+    # this action does not support the "body" parameter.
+    - name: Create release tag
+      uses: fleskesvor/create-release@1a72e235c178bf2ae6c51a8ae36febc24568c5fe
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ steps.preflight.outputs.version }}
+        release_name: Firebase Admin .NET SDK ${{ steps.preflight.outputs.version }}
+        body: ${{ steps.preflight.outputs.changelog }}
+        draft: false
+        prerelease: false
+
+    - name: Publish to Nuget
+      run: ./.github/scripts/publish_package.sh
+      env:
+        NUGET_KEY: ${{ secrets.NUGET_KEY }}
+        VERSION: ${{ steps.preflight.outputs.version }}
+
+    # Post to Twitter if explicitly opted-in by adding the label 'release:tweet'.
+    - name: Post to Twitter
+      if: success() &&
+        contains(github.event.pull_request.labels.*.name, 'release:tweet')
+      uses: firebase/firebase-admin-node/.github/actions/send-tweet
+      with:
+        status: >
+          ${{ steps.preflight.outputs.version }} of @Firebase Admin .NET SDK is avaialble.
+          https://github.com/firebase/firebase-admin-dotnet/releases/tag/${{ steps.preflight.outputs.version }}
+        consumer-key: ${{ secrets.TWITTER_CONSUMER_KEY }}
+        consumer-secret: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+        access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
+        access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+      continue-on-error: true


### PR DESCRIPTION
Running this portion of the release workflow on Linux, so we can reuse the same shell scripts for preflight and changelog generation.