### PR TITLE
chore: Add instructions to CONTRIBUTING.md for manually enabling Email/Password authentication

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,10 +153,9 @@ required to ensure that exported user records contain the password hashes of the
 3. Click 'ADD ANOTHER ROLE' and choose 'Firebase Authentication Admin'.
 4. Click 'SAVE'.
 
-For some of the authentication integration tests, it is required to manually enable Email/Password 
-functionality:
+For some of the Firebase Auth integration tests, it is required to enable the Email/Password sign-in method:
 1. Go to the [Firebase console](https://console.firebase.google.com).
-2. Click on 'Authentication', 'Sign-in method'.
+2. Click on 'Authentication', and select the 'Sign-in method' tab. 
 3. Enable 'Email/Password'.
 4. Enable 'Email link (passwordless sign-in)'.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,6 +153,13 @@ required to ensure that exported user records contain the password hashes of the
 3. Click 'ADD ANOTHER ROLE' and choose 'Firebase Authentication Admin'.
 4. Click 'SAVE'.
 
+For some of the authentication integration tests, it is required to manually enable Email/Password 
+functionality:
+1. Go to the [Firebase console](https://console.firebase.google.com).
+2. Click on 'Authentication', 'Sign-in method'.
+3. Enable 'Email/Password'.
+4. Enable 'Email link (passwordless sign-in)'.
+
 Finally, to run the integration test suite:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,8 @@ required to ensure that exported user records contain the password hashes of the
 3. Click 'ADD ANOTHER ROLE' and choose 'Firebase Authentication Admin'.
 4. Click 'SAVE'.
 
-For some of the Firebase Auth integration tests, it is required to enable the Email/Password sign-in method:
+For some of the Firebase Auth integration tests, it is required to enable the Email/Password
+sign-in method:
 1. Go to the [Firebase console](https://console.firebase.google.com).
 2. Click on 'Authentication', and select the 'Sign-in method' tab. 
 3. Enable 'Email/Password'.


### PR DESCRIPTION
Addresses #183, which requires additional setup instructions for allowing authentication integration tests to pass. 

Resolves #183 