### PR TITLE
Address feedback for user import unit tests

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Hash/UserImportHashTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Hash/UserImportHashTest.cs
@@ -20,13 +20,13 @@ namespace FirebaseAdmin.Auth.Hash.Tests
 {
     public class UserImportHashTest
     {
-        private static byte[] signerKey = System.Text.Encoding.UTF8.GetBytes("key%20");
-        private static byte[] saltSeperator = System.Text.Encoding.UTF8.GetBytes("separator");
+        private static readonly byte[] SignerKey = System.Text.Encoding.UTF8.GetBytes("key%20");
+        private static readonly byte[] SaltSeperator = System.Text.Encoding.UTF8.GetBytes("separator");
 
         [Fact]
-        public void TestBase()
+        public void Base()
         {
-            UserImportHash hash = new MockHash();
+            var hash = new MockHash();
             var props = hash.GetProperties();
 
             var expectedResult = new Dictionary<string, object>
@@ -39,13 +39,13 @@ namespace FirebaseAdmin.Auth.Hash.Tests
         }
 
         [Fact]
-        public void TestScryptHash()
+        public void ScryptHash()
         {
             var scryptHash = new Scrypt()
             {
                 Rounds = 8,
-                Key = signerKey,
-                SaltSeparator = saltSeperator,
+                Key = SignerKey,
+                SaltSeparator = SaltSeperator,
                 MemoryCost = 13,
             };
             var props = scryptHash.GetProperties();
@@ -54,8 +54,8 @@ namespace FirebaseAdmin.Auth.Hash.Tests
             {
                 { "hashAlgorithm", "SCRYPT" },
                 { "rounds", 8 },
-                { "signerKey", signerKey },
-                { "saltSeparator", saltSeperator },
+                { "signerKey", SignerKey },
+                { "saltSeparator", SaltSeperator },
                 { "memoryCost", 13 },
             };
 
@@ -63,7 +63,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
         }
 
         [Fact]
-        public void TestStandardScryptHash()
+        public void StandardScryptHash()
         {
             UserImportHash hash = new StandardScrypt()
             {
@@ -87,7 +87,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
         }
 
         [Fact]
-        public void TestRepeatableHashes()
+        public void RepeatableHashes()
         {
             var repeatableHashes = new Dictionary<string, RepeatableHash>()
             {
@@ -111,7 +111,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
         }
 
         [Fact]
-        public void TestRepeatableHashesNoRounds()
+        public void RepeatableHashesNoRounds()
         {
             var repeatableHashes = new Dictionary<string, RepeatableHash>()
             {
@@ -130,14 +130,14 @@ namespace FirebaseAdmin.Auth.Hash.Tests
         }
 
         [Fact]
-        public void TestHmacHashes()
+        public void HmacHashes()
         {
             var hmacHashes = new Dictionary<string, Hmac>()
             {
-                { "HMAC_MD5", new HmacMd5 { Key = signerKey } },
-                { "HMAC_SHA1", new HmacSha1 { Key = signerKey } },
-                { "HMAC_SHA256", new HmacSha256 { Key = signerKey } },
-                { "HMAC_SHA512", new HmacSha512 { Key = signerKey } },
+                { "HMAC_MD5", new HmacMd5 { Key = SignerKey } },
+                { "HMAC_SHA1", new HmacSha1 { Key = SignerKey } },
+                { "HMAC_SHA256", new HmacSha256 { Key = SignerKey } },
+                { "HMAC_SHA512", new HmacSha512 { Key = SignerKey } },
             };
 
             foreach (var entry in hmacHashes)
@@ -145,14 +145,14 @@ namespace FirebaseAdmin.Auth.Hash.Tests
                 var expected = new Dictionary<string, object>()
                 {
                     { "hashAlgorithm", entry.Key },
-                    { "signerKey", signerKey },
+                    { "signerKey", SignerKey },
                 };
                 Assert.Equal(expected, entry.Value.GetProperties());
             }
         }
 
         [Fact]
-        public void TestHmacHashesNoKey()
+        public void HmacHashesNoKey()
         {
             var hmacHashes = new Dictionary<string, Hmac>()
             {
@@ -169,7 +169,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
         }
 
         [Fact]
-        public void TestRepeatableHashRoundsTooLow()
+        public void RepeatableHashRoundsTooLow()
         {
             Assert.Throws<ArgumentException>(() => new Md5 { Rounds = -1 }.GetProperties());
             Assert.Throws<ArgumentException>(() => new Sha1 { Rounds = 0 }.GetProperties());
@@ -181,7 +181,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
         }
 
         [Fact]
-        public void TestRepeatableHashRoundsTooHigh()
+        public void RepeatableHashRoundsTooHigh()
         {
             Assert.Throws<ArgumentException>(() => new Md5 { Rounds = 8193 }.GetProperties());
             Assert.Throws<ArgumentException>(() => new Sha1 { Rounds = 8193 }.GetProperties());
@@ -194,67 +194,55 @@ namespace FirebaseAdmin.Auth.Hash.Tests
         }
 
         [Fact]
-        public void TestScryptHashConstraintsTooLow()
+        public void ScryptHashConstraintsTooLow()
         {
             var scryptHash = new Scrypt()
             {
                 Rounds = -1,
-                Key = signerKey,
-                SaltSeparator = saltSeperator,
+                Key = SignerKey,
+                SaltSeparator = SaltSeperator,
                 MemoryCost = 3,
             };
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                scryptHash.GetProperties();
-            });
+            Assert.Throws<ArgumentException>(() => scryptHash.GetProperties());
 
             scryptHash = new Scrypt()
             {
                 Rounds = 3,
-                Key = signerKey,
-                SaltSeparator = saltSeperator,
+                Key = SignerKey,
+                SaltSeparator = SaltSeperator,
                 MemoryCost = 0,
             };
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                scryptHash.GetProperties();
-            });
+            Assert.Throws<ArgumentException>(() => scryptHash.GetProperties());
         }
 
         [Fact]
-        public void TestScryptHashConstraintsTooHigh()
+        public void ScryptHashConstraintsTooHigh()
         {
             var scryptHash = new Scrypt()
             {
                 Rounds = 9,
-                Key = signerKey,
-                SaltSeparator = saltSeperator,
+                Key = SignerKey,
+                SaltSeparator = SaltSeperator,
                 MemoryCost = 3,
             };
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                scryptHash.GetProperties();
-            });
+            Assert.Throws<ArgumentException>(() => scryptHash.GetProperties());
 
             scryptHash = new Scrypt()
             {
                 Rounds = 3,
-                Key = signerKey,
-                SaltSeparator = saltSeperator,
+                Key = SignerKey,
+                SaltSeparator = SaltSeperator,
                 MemoryCost = 15,
             };
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                scryptHash.GetProperties();
-            });
+            Assert.Throws<ArgumentException>(() => scryptHash.GetProperties());
         }
 
         [Fact]
-        public void TestStandardScryptHashConstraintsTooLow()
+        public void StandardScryptHashConstraintsTooLow()
         {
             var standardScryptHash = new StandardScrypt()
             {
@@ -264,10 +252,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
                 MemoryCost = 13,
             };
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                standardScryptHash.GetProperties();
-            });
+            Assert.Throws<ArgumentException>(() => standardScryptHash.GetProperties());
 
             standardScryptHash = new StandardScrypt()
             {
@@ -277,10 +262,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
                 MemoryCost = 13,
             };
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                standardScryptHash.GetProperties();
-            });
+            Assert.Throws<ArgumentException>(() => standardScryptHash.GetProperties());
 
             standardScryptHash = new StandardScrypt()
             {
@@ -290,10 +272,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
                 MemoryCost = 13,
             };
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                standardScryptHash.GetProperties();
-            });
+            Assert.Throws<ArgumentException>(() => standardScryptHash.GetProperties());
 
             standardScryptHash = new StandardScrypt()
             {
@@ -303,10 +282,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
                 MemoryCost = -1,
             };
 
-            Assert.Throws<ArgumentException>(() =>
-            {
-                standardScryptHash.GetProperties();
-            });
+            Assert.Throws<ArgumentException>(() => standardScryptHash.GetProperties());
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/UserImportOptionsTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/UserImportOptionsTest.cs
@@ -14,14 +14,15 @@
 
 using System;
 using System.Collections.Generic;
+using FirebaseAdmin.Auth.Hash;
 using Xunit;
 
-namespace FirebaseAdmin.Auth.Hash.Tests
+namespace FirebaseAdmin.Auth.Tests
 {
     public class UserImportOptionsTest
     {
         [Fact]
-        public void TestUserImportOptionsBasic()
+        public void UserImportOptionsBasic()
         {
             var options = new UserImportOptions()
             {
@@ -38,7 +39,7 @@ namespace FirebaseAdmin.Auth.Hash.Tests
         }
 
         [Fact]
-        public void TestUserImportOptionsNoHash()
+        public void UserImportOptionsNoHash()
         {
             var options = new UserImportOptions();
             Assert.Throws<ArgumentException>(() => options.GetHashProperties());

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/UserProviderTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/UserProviderTest.cs
@@ -22,27 +22,41 @@ namespace FirebaseAdmin.Auth.Tests
         [Fact]
         public void NoUid()
         {
-            Assert.Throws<ArgumentException>(() => new UserProvider().Uid);
+            var userProvider = new UserProvider()
+            {
+                ProviderId = "abc",
+            };
+            Assert.Throws<ArgumentException>(() => userProvider.ToRequest());
         }
 
         [Fact]
         public void EmptyUid()
         {
-            var userProvider = new UserProvider();
-            Assert.Throws<ArgumentException>(() => userProvider.Uid = string.Empty);
+            var userProvider = new UserProvider()
+            {
+                Uid = string.Empty,
+            };
+            Assert.Throws<ArgumentException>(() => userProvider.ToRequest());
         }
 
         [Fact]
         public void NoProviderId()
         {
-            Assert.Throws<ArgumentException>(() => new UserProvider().ProviderId);
+            var userProvider = new UserProvider()
+            {
+                Uid = "abc",
+            };
+            Assert.Throws<ArgumentException>(() => userProvider.ToRequest());
         }
 
         [Fact]
         public void EmptyProviderId()
         {
-            var userProvider = new UserProvider();
-            Assert.Throws<ArgumentException>(() => userProvider.ProviderId = string.Empty);
+            var userProvider = new UserProvider()
+            {
+                ProviderId = string.Empty,
+            };
+            Assert.Throws<ArgumentException>(() => userProvider.ToRequest());
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Hash/Sha1.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Hash/Sha1.cs
@@ -24,7 +24,7 @@ namespace FirebaseAdmin.Auth.Hash
         /// Initializes a new instance of the <see cref="Sha1"/> class.
         /// Defines the name of the hash to be equal to SHA1.
         /// </summary>
-        internal Sha1()
+        public Sha1()
             : base("SHA1") { }
 
         /// <summary>

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Hash/Sha256.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Hash/Sha256.cs
@@ -24,7 +24,7 @@ namespace FirebaseAdmin.Auth.Hash
         /// Initializes a new instance of the <see cref="Sha256"/> class.
         /// Defines the name of the hash to be equal to SHA256.
         /// </summary>
-        internal Sha256()
+        public Sha256()
             : base("SHA256") { }
 
         /// <summary>

--- a/FirebaseAdmin/FirebaseAdmin/Auth/ImportUserRecordArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/ImportUserRecordArgs.cs
@@ -133,7 +133,8 @@ namespace FirebaseAdmin.Auth
 
                 if (args.UserProviders != null && args.UserProviders.Count() > 0)
                 {
-                    this.ProviderUserInfo = new List<UserProvider>(args.UserProviders);
+                    this.ProviderUserInfo = new List<UserProvider.Request>(
+                        args.UserProviders.Select(userProvider => userProvider.ToRequest()));
                 }
 
                 if (args.CustomClaims != null && args.CustomClaims.Count > 0)
@@ -146,41 +147,41 @@ namespace FirebaseAdmin.Auth
                 this.Disabled = args.Disabled;
             }
 
-            [JsonProperty("createdAt")]
+            [JsonProperty("createdAt", NullValueHandling = NullValueHandling.Ignore)]
             public DateTime? CreatedAt { get; set; }
 
-            [JsonProperty("customAttributes")]
+            [JsonProperty("customAttributes", NullValueHandling = NullValueHandling.Ignore)]
             public string CustomAttributes { get; set; }
 
-            [JsonProperty("disabled")]
+            [JsonProperty("disabled", NullValueHandling = NullValueHandling.Ignore)]
             public bool? Disabled { get; set; }
 
-            [JsonProperty("displayName")]
+            [JsonProperty("displayName", NullValueHandling = NullValueHandling.Ignore)]
             public string DisplayName { get; set; }
 
-            [JsonProperty("email")]
+            [JsonProperty("email", NullValueHandling = NullValueHandling.Ignore)]
             public string Email { get; set; }
 
-            [JsonProperty("emailVerified")]
+            [JsonProperty("emailVerified", NullValueHandling = NullValueHandling.Ignore)]
             public bool? EmailVerified { get; set; }
 
-            [JsonProperty("lastLoginAt")]
+            [JsonProperty("lastLoginAt", NullValueHandling = NullValueHandling.Ignore)]
             public DateTime? LastLoginAt { get; set; }
 
-            [JsonProperty("passwordHash")]
+            [JsonProperty("passwordHash", NullValueHandling = NullValueHandling.Ignore)]
             public string PasswordHash { get; set; }
 
-            [JsonProperty("salt")]
+            [JsonProperty("salt", NullValueHandling = NullValueHandling.Ignore)]
             public string PasswordSalt { get; set; }
 
-            [JsonProperty("phoneNumber")]
+            [JsonProperty("phoneNumber", NullValueHandling = NullValueHandling.Ignore)]
             public string PhoneNumber { get; set; }
 
-            [JsonProperty("photoUrl")]
+            [JsonProperty("photoUrl", NullValueHandling = NullValueHandling.Ignore)]
             public string PhotoUrl { get; set; }
 
-            [JsonProperty("providerUserInfo")]
-            public List<UserProvider> ProviderUserInfo { get; set; }
+            [JsonProperty("providerUserInfo", NullValueHandling = NullValueHandling.Ignore)]
+            public List<UserProvider.Request> ProviderUserInfo { get; set; }
 
             [JsonProperty("localId")]
             public string Uid { get; set; }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/UserMetadata.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/UserMetadata.cs
@@ -31,7 +31,7 @@ namespace FirebaseAdmin.Auth
         /// <param name="creationTimestamp">A timestamp representing the date and time that the user account was created.</param>
         /// <param name="lastSignInTimestamp">A timestamp representing the date and time that the user account was last signed-on to.</param>
         /// <param name="lastRefreshTimestamp">A timestamp representing the date and time that the user account was last refreshed.</param>
-        internal UserMetadata(long creationTimestamp, long lastSignInTimestamp, DateTime? lastRefreshTimestamp)
+        public UserMetadata(long creationTimestamp, long lastSignInTimestamp, DateTime? lastRefreshTimestamp)
         {
             this.creationTimestampMillis = creationTimestamp;
             this.lastSignInTimestampMillis = lastSignInTimestamp;

--- a/FirebaseAdmin/FirebaseAdmin/Auth/UserProvider.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/UserProvider.cs
@@ -22,81 +22,79 @@ namespace FirebaseAdmin.Auth
     /// </summary>
     public sealed class UserProvider
     {
-        private string uid;
-
-        private string providerId;
-
         /// <summary>
         /// Gets or sets the user's unique ID assigned by the identity provider. This field is required.
         /// </summary>
-        [JsonProperty("rawId")]
-        public string Uid
-        {
-            get
-            {
-                if (string.IsNullOrEmpty(this.uid))
-                {
-                    throw new ArgumentException("Uid must not be null or empty");
-                }
-
-                return this.uid;
-            }
-
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                {
-                    throw new ArgumentException("Uid must not be null or empty");
-                }
-
-                this.uid = value;
-            }
-        }
+        public string Uid { get; set; }
 
         /// <summary>
         /// Gets or sets the user's display name.
         /// </summary>
-        [JsonProperty("displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the user's email address.
         /// </summary>
-        [JsonProperty("email")]
         public string Email { get; set; }
 
         /// <summary>
         /// Gets or sets the photo URL of the user.
         /// </summary>
-        [JsonProperty("photoUrl")]
         public string PhotoUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the ID of the identity provider. This can be a short domain name (e.g. google.com) or
-        /// the identifier of an OpenID identity provider. This field is required.
+        /// Gets or sets the ID of the identity provider. This can be a short domain name
+        /// (e.g. google.com) or the identifier of an OpenID identity provider. This field
+        /// is required.
         /// </summary>
-        [JsonProperty("providerId")]
-        public string ProviderId
+        public string ProviderId { get; set; }
+
+        /// <summary>
+        /// Creates the serialized request object containing all the properties of UserProvider
+        /// and performs validation.
+        /// </summary>
+        /// <returns>Serializable and validated object containing UserProvier properties.</returns>
+        internal Request ToRequest()
         {
-            get
+            return new Request(this);
+        }
+
+        internal sealed class Request
+        {
+            internal Request(UserProvider userProvider)
             {
-                if (string.IsNullOrEmpty(this.providerId))
+                if (string.IsNullOrEmpty(userProvider.Uid))
+                {
+                    throw new ArgumentException("Uid must not be null or empty");
+                }
+
+                this.Uid = userProvider.Uid;
+                this.DisplayName = userProvider.DisplayName;
+                this.Email = userProvider.Email;
+                this.PhotoUrl = userProvider.PhotoUrl;
+
+                if (string.IsNullOrEmpty(userProvider.ProviderId))
                 {
                     throw new ArgumentException("ProviderId must not be null or empty");
                 }
 
-                return this.providerId;
+                this.ProviderId = userProvider.ProviderId;
             }
 
-            set
-            {
-                if (string.IsNullOrEmpty(value))
-                {
-                    throw new ArgumentException("ProviderId must not be null or empty");
-                }
+            [JsonProperty("rawId")]
+            public string Uid { get; set; }
 
-                this.providerId = value;
-            }
+            [JsonProperty("displayName")]
+            public string DisplayName { get; set; }
+
+            [JsonProperty("email")]
+            public string Email { get; set; }
+
+            [JsonProperty("photoUrl")]
+            public string PhotoUrl { get; set; }
+
+            [JsonProperty("providerId")]
+            public string ProviderId { get; set; }
         }
     }
 }


### PR DESCRIPTION
This is a separate pull request because the other PR was getting too big (note that it will merge back into the other `bulk-user-import` branch).

Addressed feedback from the last round of review. Another note is that I brought up the Base64Url encoding prior, I think the implementation is ok as it is similar to the Java behavior and it is verified by the `SignerKey` being properly URL encoded in the tests here.

One remark is the addition of `NullValueHandling = NullValueHandling.Ignore` for all properties (except Uid) when being serialized for `ImportUserRecordArgs`. 

Newtonsoft has the ability to choose to ignore null values when the serialize function is invoked, but in this case `PostAndDeserializeAsync` handles the serialization using `NewtonsoftJsonSerializer.Instance.CreateJsonHttpContent` and it would require editing the `PostAndDeserializeAsync` method. Ignoring the null values reduces the size of the serialized payload in the POST request.
