### PR TITLE
feat(auth): Added ListOidcProviderConfigsAsync() API

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
@@ -1283,6 +1283,24 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
+        /// Gets an async enumerable to iterate or page through OIDC provider configurations
+        /// starting from the specified page token. If the page token is null or unspecified,
+        /// iteration starts from the first page. See
+        /// <a href="https://googleapis.github.io/google-cloud-dotnet/docs/guides/page-streaming.html">
+        /// Page Streaming</a> for more details on how to use this API.
+        /// </summary>
+        /// <param name="options">The options to control the starting point and page size. Pass null
+        /// to list from the beginning with default settings.</param>
+        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, OidcProviderConfig}"/> instance.</returns>
+        public PagedAsyncEnumerable<AuthProviderConfigs<OidcProviderConfig>, OidcProviderConfig>
+            ListOidcProviderConfigsAsync(ListProviderConfigsOptions options)
+        {
+            var providerConfigManager = this.IfNotDeleted(
+                () => this.providerConfigManager.Value);
+            return providerConfigManager.ListOidcProviderConfigsAsync(options);
+        }
+
+        /// <summary>
         /// Deletes this <see cref="FirebaseAuth"/> service instance.
         /// </summary>
         void IFirebaseService.Delete()

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/AuthProviderConfigs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/AuthProviderConfigs.cs
@@ -1,0 +1,37 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+
+namespace FirebaseAdmin.Auth.Providers
+{
+    /// <summary>
+    /// A page of auth provider configurations.
+    /// </summary>
+    /// <typeparam name="T">Type of <see cref="AuthProviderConfig"/> that is included.</typeparam>
+    public sealed class AuthProviderConfigs<T>
+    where T : AuthProviderConfig
+    {
+        /// <summary>
+        /// Gets the token representing the next page of auth provider configurations. Null if
+        /// there are no more pages.
+        /// </summary>
+        public string NextPageToken { get; internal set; }
+
+        /// <summary>
+        /// Gets the auth provider configurations included in the current page.
+        /// </summary>
+        public IEnumerable<T> ProviderConfigs { get; internal set; }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListOidcProviderConfigsRequest.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListOidcProviderConfigsRequest.cs
@@ -1,0 +1,66 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using FirebaseAdmin.Util;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace FirebaseAdmin.Auth.Providers
+{
+    /// <summary>
+    /// A request made using the Google API client to list all OIDC provider configurations in a
+    /// Firebase project.
+    /// </summary>
+    internal sealed class ListOidcProviderConfigsRequest
+    : ListProviderConfigsRequest<OidcProviderConfig>
+    {
+        internal ListOidcProviderConfigsRequest(
+            string baseUrl,
+            ErrorHandlingHttpClient<FirebaseAuthException> httpClient,
+            ListProviderConfigsOptions options)
+            : base(baseUrl, httpClient, options) { }
+
+        public override string MethodName => "ListOidcProviderConfigs";
+
+        public override string RestPath => "oauthIdpConfigs";
+
+        protected override AuthProviderConfigs<OidcProviderConfig> BuildProviderConfigs(JObject json)
+        {
+            var response = json.ToObject<Response>();
+            var configs = response.Configs?.Select(config => new OidcProviderConfig(config));
+            return new AuthProviderConfigs<OidcProviderConfig>
+            {
+                NextPageToken = response.NextPageToken,
+                ProviderConfigs = configs,
+            };
+        }
+
+        internal sealed class Response
+        {
+            /// <summary>
+            /// Gets or sets the next page link.
+            /// </summary>
+            [JsonProperty("nextPageToken")]
+            public string NextPageToken { get; set; }
+
+            /// <summary>
+            /// Gets or sets the users.
+            /// </summary>
+            [JsonProperty("oauthIdpConfigs")]
+            public IEnumerable<OidcProviderConfig.Request> Configs { get; set; }
+        }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListProviderConfigsOptions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListProviderConfigsOptions.cs
@@ -1,0 +1,34 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace FirebaseAdmin.Auth.Providers
+{
+    /// <summary>
+    /// Options for listing auth provider configurations.
+    /// </summary>
+    public sealed class ListProviderConfigsOptions
+    {
+        /// <summary>
+        /// Gets or sets the number of results to fetch in a single API call. This does not affect
+        /// the total number of results returned. Must not exceed 100.
+        /// </summary>
+        public int? PageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the page token. If set, this token is used to indicate a continued list
+        /// operation.
+        /// </summary>
+        public string PageToken { get; set; }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListProviderConfigsPageManager.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListProviderConfigsPageManager.cs
@@ -1,0 +1,47 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Google.Api.Gax.Rest;
+
+namespace FirebaseAdmin.Auth.Providers
+{
+    /// <summary>
+    /// Utility for paging through provider configs using the Google API client.
+    /// </summary>
+    internal sealed class ListProviderConfigsPageManager<T>
+    : IPageManager<ListProviderConfigsRequest<T>, AuthProviderConfigs<T>, T>
+    where T : AuthProviderConfig
+    {
+        public void SetPageSize(ListProviderConfigsRequest<T> request, int pageSize)
+        {
+            request.SetPageSize(pageSize);
+        }
+
+        public void SetPageToken(ListProviderConfigsRequest<T> request, string pageToken)
+        {
+            request.SetPageToken(pageToken);
+        }
+
+        public IEnumerable<T> GetResources(AuthProviderConfigs<T> response)
+        {
+            return response?.ProviderConfigs;
+        }
+
+        public string GetNextPageToken(AuthProviderConfigs<T> response)
+        {
+            return string.IsNullOrEmpty(response.NextPageToken) ? null : response.NextPageToken;
+        }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListProviderConfigsRequest.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListProviderConfigsRequest.cs
@@ -114,7 +114,7 @@ namespace FirebaseAdmin.Auth.Providers
         {
             if (pageSize > MaxListResults)
             {
-                throw new ArgumentException("Page size must not exceed 100.");
+                throw new ArgumentException($"Page size must not exceed {MaxListResults}.");
             }
             else if (pageSize <= 0)
             {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListProviderConfigsRequest.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ListProviderConfigsRequest.cs
@@ -1,0 +1,165 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using FirebaseAdmin.Util;
+using Google.Apis.Discovery;
+using Google.Apis.Requests;
+using Google.Apis.Services;
+using Newtonsoft.Json.Linq;
+
+namespace FirebaseAdmin.Auth.Providers
+{
+    /// <summary>
+    /// A request made using the Google API client to list all auth provider configurations in a
+    /// Firebase project.
+    /// </summary>
+    internal abstract class ListProviderConfigsRequest<T>
+    : IClientServiceRequest<AuthProviderConfigs<T>>
+    where T : AuthProviderConfig
+    {
+        private const int MaxListResults = 100;
+
+        private readonly string baseUrl;
+        private readonly ErrorHandlingHttpClient<FirebaseAuthException> httpClient;
+
+        protected ListProviderConfigsRequest(
+            string baseUrl,
+            ErrorHandlingHttpClient<FirebaseAuthException> httpClient,
+            ListProviderConfigsOptions options)
+        {
+            this.baseUrl = baseUrl;
+            this.httpClient = httpClient;
+            this.RequestParameters = new Dictionary<string, IParameter>();
+            this.SetPageSize(options?.PageSize);
+            this.SetPageToken(options?.PageToken);
+        }
+
+        public abstract string MethodName { get; }
+
+        public abstract string RestPath { get; }
+
+        public string HttpMethod => "GET";
+
+        public IDictionary<string, IParameter> RequestParameters { get; }
+
+        public IClientService Service { get; }
+
+        public HttpRequestMessage CreateRequest(bool? overrideGZipEnabled = null)
+        {
+            var queryParameters = string.Join("&", this.RequestParameters.Select(
+                kvp => $"{kvp.Key}={kvp.Value.DefaultValue}"));
+            var request = new HttpRequestMessage()
+            {
+                Method = System.Net.Http.HttpMethod.Get,
+                RequestUri = new Uri($"{this.baseUrl}/{this.RestPath}?{queryParameters}"),
+            };
+            request.Headers.Add(
+                ProviderConfigManager.ClientVersionHeader, ProviderConfigManager.ClientVersion);
+            return request;
+        }
+
+        public async Task<Stream> ExecuteAsStreamAsync(CancellationToken cancellationToken)
+        {
+            var response = await this.httpClient.SendAsync(this.CreateRequest(), cancellationToken)
+                .ConfigureAwait(false);
+            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        }
+
+        public Stream ExecuteAsStream()
+        {
+            return this.ExecuteAsStreamAsync().Result;
+        }
+
+        public async Task<Stream> ExecuteAsStreamAsync()
+        {
+            return await this.ExecuteAsStreamAsync(default).ConfigureAwait(false);
+        }
+
+        public AuthProviderConfigs<T> Execute()
+        {
+            return this.ExecuteAsync().Result;
+        }
+
+        public async Task<AuthProviderConfigs<T>> ExecuteAsync()
+        {
+            return await this.ExecuteAsync(default).ConfigureAwait(false);
+        }
+
+        public async Task<AuthProviderConfigs<T>> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            var jObject = await this.SendAndDeserializeAsync(cancellationToken)
+                .ConfigureAwait(false);
+            return this.BuildProviderConfigs(jObject);
+        }
+
+        internal void SetPageSize(int? pageSize)
+        {
+            if (pageSize > MaxListResults)
+            {
+                throw new ArgumentException("Page size must not exceed 100.");
+            }
+            else if (pageSize <= 0)
+            {
+                throw new ArgumentException("Page size must be positive.");
+            }
+
+            this.AddOrUpdate("pageSize", (pageSize ?? MaxListResults).ToString());
+        }
+
+        internal void SetPageToken(string pageToken)
+        {
+            if (pageToken != null)
+            {
+                if (pageToken == string.Empty)
+                {
+                    throw new ArgumentException("Page token must not be empty.");
+                }
+
+                this.AddOrUpdate("pageToken", pageToken);
+            }
+            else
+            {
+                this.RequestParameters.Remove("pageToken");
+            }
+        }
+
+        protected abstract AuthProviderConfigs<T> BuildProviderConfigs(JObject json);
+
+        private async Task<JObject> SendAndDeserializeAsync(CancellationToken cancellationToken)
+        {
+            var request = this.CreateRequest();
+            var response = await this.httpClient
+                .SendAndDeserializeAsync<JObject>(request, cancellationToken)
+                .ConfigureAwait(false);
+            return response.Result;
+        }
+
+        private void AddOrUpdate(string paramName, string value)
+        {
+            this.RequestParameters[paramName] = new Parameter()
+            {
+                DefaultValue = value,
+                IsRequired = true,
+                Name = paramName,
+            };
+        }
+    }
+}


### PR DESCRIPTION
Added the method for listing OIDC provider configs:

```
PagedAsyncEnumerable<AuthProviderConfigs<OidcProviderConfig>, OidcProviderConfig> 
  ListOidcProviderConfigsAsync(ListProviderConfigsOptions options)
```

Elements of the implementation mostly copied from the existing `ListUsersAsync()` API. Uses REST API utils provided by `Google.Api.Gax` to handle paging.