### PR TITLE
fix: Moving common rpc logic to ProviderConfigClient

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigClient.cs
@@ -18,9 +18,6 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
-using Google.Api.Gax;
-using Google.Api.Gax.Rest;
-using Google.Apis.Json;
 using Newtonsoft.Json;
 
 namespace FirebaseAdmin.Auth.Providers
@@ -33,84 +30,11 @@ namespace FirebaseAdmin.Auth.Providers
 
         private OidcProviderConfigClient() { }
 
-        internal override async Task<OidcProviderConfig> GetProviderConfigAsync(
-            ApiClient client, string providerId, CancellationToken cancellationToken)
-        {
-            var request = new HttpRequestMessage()
-            {
-                Method = HttpMethod.Get,
-                RequestUri = BuildUri($"oauthIdpConfigs/{this.ValidateProviderId(providerId)}"),
-            };
-            var response = await client
-                .SendAndDeserializeAsync<OidcProviderConfig.Request>(request, cancellationToken)
-                .ConfigureAwait(false);
-            return new OidcProviderConfig(response);
-        }
+        protected override string ResourcePath => "oauthIdpConfigs";
 
-        internal override async Task<OidcProviderConfig> CreateProviderConfigAsync(
-            ApiClient client,
-            AuthProviderConfigArgs<OidcProviderConfig> args,
-            CancellationToken cancellationToken)
-        {
-            var query = new Dictionary<string, object>()
-            {
-                { "oauthIdpConfigId", this.ValidateProviderId(args.ProviderId) },
-            };
-            var request = new HttpRequestMessage()
-            {
-                Method = HttpMethod.Post,
-                RequestUri = BuildUri("oauthIdpConfigs", query),
-                Content = NewtonsoftJsonSerializer.Instance.CreateJsonHttpContent(
-                    args.ToCreateRequest()),
-            };
-            var response = await client
-                .SendAndDeserializeAsync<OidcProviderConfig.Request>(request, cancellationToken)
-                .ConfigureAwait(false);
-            return new OidcProviderConfig(response);
-        }
+        protected override string ProviderIdParam => "oauthIdpConfigId";
 
-        internal override async Task<OidcProviderConfig> UpdateProviderConfigAsync(
-            ApiClient client,
-            AuthProviderConfigArgs<OidcProviderConfig> args,
-            CancellationToken cancellationToken)
-        {
-            var providerId = this.ValidateProviderId(args.ProviderId);
-            var content = args.ToUpdateRequest();
-            var updateMask = CreateUpdateMask(content);
-            if (updateMask.Count == 0)
-            {
-                throw new ArgumentException("At least one field must be specified for update.");
-            }
-
-            var query = new Dictionary<string, object>()
-            {
-                { "updateMask", string.Join(",", updateMask) },
-            };
-            var request = new HttpRequestMessage()
-            {
-                Method = Patch,
-                RequestUri = BuildUri($"oauthIdpConfigs/{providerId}", query),
-                Content = NewtonsoftJsonSerializer.Instance.CreateJsonHttpContent(content),
-            };
-            var response = await client
-                .SendAndDeserializeAsync<OidcProviderConfig.Request>(request, cancellationToken)
-                .ConfigureAwait(false);
-            return new OidcProviderConfig(response);
-        }
-
-        internal override PagedAsyncEnumerable<AuthProviderConfigs<OidcProviderConfig>, OidcProviderConfig>
-            ListProviderConfigsAsync(ApiClient client, ListProviderConfigsOptions options)
-        {
-            var request = new ListRequest(client, options);
-            return new RestPagedAsyncEnumerable
-                <
-                    AbstractListRequest,
-                    AuthProviderConfigs<OidcProviderConfig>,
-                    OidcProviderConfig
-                >(() => request, new PageManager());
-        }
-
-        private string ValidateProviderId(string providerId)
+        protected override string ValidateProviderId(string providerId)
         {
             if (string.IsNullOrEmpty(providerId))
             {
@@ -123,6 +47,21 @@ namespace FirebaseAdmin.Auth.Providers
             }
 
             return providerId;
+        }
+
+        protected override async Task<OidcProviderConfig> SendAndDeserializeAsync(
+            ApiClient client, HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var response = await client
+                .SendAndDeserializeAsync<OidcProviderConfig.Request>(request, cancellationToken)
+                .ConfigureAwait(false);
+            return new OidcProviderConfig(response);
+        }
+
+        protected override AbstractListRequest CreateListRequest(
+            ApiClient client, ListProviderConfigsOptions options)
+        {
+            return new ListRequest(client, options);
         }
 
         private sealed class ListRequest : AbstractListRequest


### PR DESCRIPTION
Lot of the RPC handling logic is duplicated across `OidcProviderConfigClient` and `SamlProviderConfigClient`. This refactor moves all the common code into the parent class, and let the child classes customize only the necessary bits.