### PR TITLE
feat(auth): Added ListSamlProviderConfigs API

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -379,11 +379,11 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             Assert.All(configs, this.AssertOidcProviderConfig);
 
             Assert.Equal(2, handler.Requests.Count);
-            var query = this.ExtractQueryParams(handler.Requests[0]);
+            var query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[0]);
             Assert.Single(query);
             Assert.Equal("100", query["pageSize"]);
 
-            query = this.ExtractQueryParams(handler.Requests[1]);
+            query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[1]);
             Assert.Equal(2, query.Count);
             Assert.Equal("100", query["pageSize"]);
             Assert.Equal("token", query["pageToken"]);
@@ -411,11 +411,11 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             Assert.All(configs, this.AssertOidcProviderConfig);
 
             Assert.Equal(2, handler.Requests.Count);
-            var query = this.ExtractQueryParams(handler.Requests[0]);
+            var query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[0]);
             Assert.Single(query);
             Assert.Equal("100", query["pageSize"]);
 
-            query = this.ExtractQueryParams(handler.Requests[1]);
+            query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[1]);
             Assert.Equal(2, query.Count);
             Assert.Equal("100", query["pageSize"]);
             Assert.Equal("token", query["pageToken"]);
@@ -441,7 +441,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             Assert.Equal("token", configPage.NextPageToken);
 
             Assert.Single(handler.Requests);
-            var query = this.ExtractQueryParams(handler.Requests[0]);
+            var query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[0]);
             Assert.Single(query);
             Assert.Equal("3", query["pageSize"]);
             configs.AddRange(configPage);
@@ -457,7 +457,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             Assert.Null(configPage.NextPageToken);
 
             Assert.Equal(2, handler.Requests.Count);
-            query = this.ExtractQueryParams(handler.Requests[1]);
+            query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[1]);
             Assert.Equal(2, query.Count);
             Assert.Equal("3", query["pageSize"]);
             Assert.Equal("token", query["pageToken"]);
@@ -492,11 +492,11 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             Assert.All(configs, this.AssertOidcProviderConfig);
 
             Assert.Equal(2, handler.Requests.Count);
-            var query = this.ExtractQueryParams(handler.Requests[0]);
+            var query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[0]);
             Assert.Single(query);
             Assert.Equal("100", query["pageSize"]);
 
-            query = this.ExtractQueryParams(handler.Requests[1]);
+            query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[1]);
             Assert.Equal(2, query.Count);
             Assert.Equal("100", query["pageSize"]);
             Assert.Equal("token", query["pageToken"]);
@@ -527,12 +527,12 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             Assert.All(configs, this.AssertOidcProviderConfig);
 
             Assert.Equal(2, handler.Requests.Count);
-            var query = this.ExtractQueryParams(handler.Requests[0]);
+            var query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[0]);
             Assert.Equal(2, query.Count);
             Assert.Equal("3", query["pageSize"]);
             Assert.Equal("custom-token", query["pageToken"]);
 
-            query = this.ExtractQueryParams(handler.Requests[1]);
+            query = ProviderConfigTestUtils.ExtractQueryParams(handler.Requests[1]);
             Assert.Equal(2, query.Count);
             Assert.Equal("3", query["pageSize"]);
             Assert.Equal("token", query["pageToken"]);
@@ -541,7 +541,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
         }
 
         [Theory]
-        [ClassData(typeof(InvalidListOptions))]
+        [ClassData(typeof(ProviderConfigTestUtils.InvalidListOptions))]
         public void ListOidcInvalidOptions(ListProviderConfigsOptions options, string expected)
         {
             var handler = new MockMessageHandler()
@@ -549,7 +549,6 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                 Response = ListConfigsResponses,
             };
             var auth = ProviderConfigTestUtils.CreateFirebaseAuth(handler);
-            var pagedEnumerable = auth.ListOidcProviderConfigsAsync(null);
 
             var exception = Assert.Throws<ArgumentException>(
                 () => auth.ListOidcProviderConfigsAsync(options));
@@ -581,12 +580,6 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             Assert.True(provider.Enabled);
             Assert.Equal("CLIENT_ID", provider.ClientId);
             Assert.Equal("https://oidc.com/issuer", provider.Issuer);
-        }
-
-        private IDictionary<string, string> ExtractQueryParams(MockMessageHandler.IncomingRequest req)
-        {
-            return req.Url.Query.Substring(1).Split('&').ToDictionary(
-                entry => entry.Split('=')[0], entry => entry.Split('=')[1]);
         }
 
         public class InvalidCreateArgs : IEnumerable<object[]>
@@ -713,51 +706,6 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         Issuer = "not a url",
                     },
                     "Malformed issuer string: not a url",
-                };
-            }
-
-            IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
-        }
-
-        public class InvalidListOptions : IEnumerable<object[]>
-        {
-            public IEnumerator<object[]> GetEnumerator()
-            {
-                // {
-                //    1st element: InvalidInput,
-                //    2nd element: ExpectedError,
-                // }
-                yield return new object[]
-                {
-                    new ListProviderConfigsOptions()
-                    {
-                        PageSize = 101,
-                    },
-                    "Page size must not exceed 100.",
-                };
-                yield return new object[]
-                {
-                    new ListProviderConfigsOptions()
-                    {
-                        PageSize = 0,
-                    },
-                    "Page size must be positive.",
-                };
-                yield return new object[]
-                {
-                    new ListProviderConfigsOptions()
-                    {
-                        PageSize = -1,
-                    },
-                    "Page size must be positive.",
-                };
-                yield return new object[]
-                {
-                    new ListProviderConfigsOptions()
-                    {
-                        PageToken = string.Empty,
-                    },
-                    "Page token must not be empty.",
                 };
             }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/ProviderConfigTestUtils.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/ProviderConfigTestUtils.cs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using FirebaseAdmin.Tests;
 using FirebaseAdmin.Util;
@@ -60,6 +63,58 @@ namespace FirebaseAdmin.Auth.Providers.Tests
         internal static void AssertClientVersionHeader(MockMessageHandler.IncomingRequest request)
         {
             Assert.Contains(ClientVersion, request.Headers.GetValues("X-Client-Version"));
+        }
+
+        internal static IDictionary<string, string> ExtractQueryParams(
+            MockMessageHandler.IncomingRequest req)
+        {
+            return req.Url.Query.Substring(1).Split('&').ToDictionary(
+                entry => entry.Split('=')[0], entry => entry.Split('=')[1]);
+        }
+
+        public class InvalidListOptions : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                // {
+                //    1st element: InvalidInput,
+                //    2nd element: ExpectedError,
+                // }
+                yield return new object[]
+                {
+                    new ListProviderConfigsOptions()
+                    {
+                        PageSize = 101,
+                    },
+                    "Page size must not exceed 100.",
+                };
+                yield return new object[]
+                {
+                    new ListProviderConfigsOptions()
+                    {
+                        PageSize = 0,
+                    },
+                    "Page size must be positive.",
+                };
+                yield return new object[]
+                {
+                    new ListProviderConfigsOptions()
+                    {
+                        PageSize = -1,
+                    },
+                    "Page size must be positive.",
+                };
+                yield return new object[]
+                {
+                    new ListProviderConfigsOptions()
+                    {
+                        PageToken = string.Empty,
+                    },
+                    "Page token must not be empty.",
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => this.GetEnumerator();
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
@@ -1339,6 +1339,24 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
+        /// Gets an async enumerable to iterate or page through SAML provider configurations
+        /// starting from the specified page token. If the page token is null or unspecified,
+        /// iteration starts from the first page. See
+        /// <a href="https://googleapis.github.io/google-cloud-dotnet/docs/guides/page-streaming.html">
+        /// Page Streaming</a> for more details on how to use this API.
+        /// </summary>
+        /// <param name="options">The options to control the starting point and page size. Pass null
+        /// to list from the beginning with default settings.</param>
+        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, SamlProviderConfig}"/> instance.</returns>
+        public PagedAsyncEnumerable<AuthProviderConfigs<SamlProviderConfig>, SamlProviderConfig>
+            ListSamlProviderConfigsAsync(ListProviderConfigsOptions options)
+        {
+            var providerConfigManager = this.IfNotDeleted(
+                () => this.providerConfigManager.Value);
+            return providerConfigManager.ListSamlProviderConfigsAsync(options);
+        }
+
+        /// <summary>
         /// Deletes this <see cref="FirebaseAuth"/> service instance.
         /// </summary>
         void IFirebaseService.Delete()

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ProviderConfigManager.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ProviderConfigManager.cs
@@ -107,6 +107,13 @@ namespace FirebaseAdmin.Auth.Providers
                 this.apiClient, options);
         }
 
+        internal PagedAsyncEnumerable<AuthProviderConfigs<SamlProviderConfig>, SamlProviderConfig>
+            ListSamlProviderConfigsAsync(ListProviderConfigsOptions options)
+        {
+            return SamlProviderConfigClient.Instance.ListProviderConfigsAsync(
+                this.apiClient, options);
+        }
+
         internal sealed class Args
         {
             internal HttpClientFactory ClientFactory { get; set; }


### PR DESCRIPTION
Added `ListSamlProviderConfigAsync()` API to `FirebaseAuth`. Fixed a couple of issues with existing tests.