### PR TITLE
feat(auth): Added DeleteProviderConfigAsync() API

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -359,6 +359,70 @@ namespace FirebaseAdmin.Auth.Providers.Tests
         }
 
         [Fact]
+        public async Task DeleteConfig()
+        {
+            var handler = new MockMessageHandler()
+            {
+                Response = "{}",
+            };
+            var auth = ProviderConfigTestUtils.CreateFirebaseAuth(handler);
+
+            await auth.DeleteProviderConfigAsync("oidc.provider");
+
+            Assert.Equal(1, handler.Requests.Count);
+            var request = handler.Requests[0];
+            Assert.Equal(HttpMethod.Delete, request.Method);
+            Assert.Equal(
+                "/v2/projects/project1/oauthIdpConfigs/oidc.provider",
+                request.Url.PathAndQuery);
+            ProviderConfigTestUtils.AssertClientVersionHeader(request);
+        }
+
+        [Theory]
+        [MemberData(nameof(InvalidStrings))]
+        public async Task DeleteConfigNoProviderId(string providerId)
+        {
+            var auth = ProviderConfigTestUtils.CreateFirebaseAuth();
+
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => auth.DeleteProviderConfigAsync(providerId));
+        }
+
+        [Fact]
+        public async Task DeleteConfigInvalidProviderId()
+        {
+            var auth = ProviderConfigTestUtils.CreateFirebaseAuth();
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => auth.DeleteProviderConfigAsync("unknown.provider"));
+            Assert.Equal(
+                "Provider ID must have 'oidc.' or 'saml.' as the prefix.",
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task DeleteConfigNotFoundError()
+        {
+            var handler = new MockMessageHandler()
+            {
+                StatusCode = HttpStatusCode.NotFound,
+                Response = ProviderConfigTestUtils.ConfigNotFoundResponse,
+            };
+            var auth = ProviderConfigTestUtils.CreateFirebaseAuth(handler);
+
+            var exception = await Assert.ThrowsAsync<FirebaseAuthException>(
+                () => auth.DeleteProviderConfigAsync("oidc.provider"));
+            Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
+            Assert.Equal(AuthErrorCode.ConfigurationNotFound, exception.AuthErrorCode);
+            Assert.Equal(
+                "No identity provider configuration found for the given identifier "
+                + "(CONFIGURATION_NOT_FOUND).",
+                exception.Message);
+            Assert.NotNull(exception.HttpResponse);
+            Assert.Null(exception.InnerException);
+        }
+
+        [Fact]
         public async Task ListConfigs()
         {
             var handler = new MockMessageHandler()

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
@@ -1241,9 +1241,9 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
-        /// Creates a new OIDC auth provider configuration.
+        /// Creates a new auth provider configuration.
         /// </summary>
-        /// <returns>A task that completes with a <see cref="OidcProviderConfig"/>.</returns>
+        /// <returns>A task that completes with an <see cref="AuthProviderConfig"/>.</returns>
         /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
         /// invalid.</exception>
         /// <exception cref="FirebaseAuthException">If an unexpected error occurs while creating
@@ -1258,9 +1258,9 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
-        /// Creates a new OIDC auth provider configuration.
+        /// Creates a new auth provider configuration.
         /// </summary>
-        /// <returns>A task that completes with a <see cref="OidcProviderConfig"/>.</returns>
+        /// <returns>A task that completes with a <see cref="AuthProviderConfig"/>.</returns>
         /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
         /// invalid.</exception>
         /// <exception cref="FirebaseAuthException">If an unexpected error occurs while creating
@@ -1280,9 +1280,9 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
-        /// Updates an existing OIDC auth provider configuration.
+        /// Updates an existing auth provider configuration.
         /// </summary>
-        /// <returns>A task that completes with the updated <see cref="OidcProviderConfig"/>.
+        /// <returns>A task that completes with the updated <see cref="AuthProviderConfig"/>.
         /// </returns>
         /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
         /// invalid.</exception>
@@ -1298,9 +1298,9 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
-        /// Updates an existing OIDC auth provider configuration.
+        /// Updates an existing auth provider configuration.
         /// </summary>
-        /// <returns>A task that completes with the updated <see cref="OidcProviderConfig"/>.
+        /// <returns>A task that completes with the updated <see cref="AuthProviderConfig"/>.
         /// </returns>
         /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
         /// invalid.</exception>
@@ -1321,15 +1321,52 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
+        /// Deletes the specified auth provider configuration.
+        /// </summary>
+        /// <returns>A task that completes when the provider configuration is deleted.</returns>
+        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
+        /// contain either the <c>oidc.</c> or <c>saml.</c> prefix.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist.</exception>
+        /// <param name="providerId">ID of the provider configuration to delete.</param>
+        public async Task DeleteProviderConfigAsync(string providerId)
+        {
+            await this.DeleteProviderConfigAsync(providerId, default(CancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Deletes the specified auth provider configuration.
+        /// </summary>
+        /// <returns>A task that completes when the provider configuration is deleted.</returns>
+        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
+        /// contain either the <c>oidc.</c> or <c>saml.</c> prefix.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist.</exception>
+        /// <param name="providerId">ID of the provider configuration to delete.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        public async Task DeleteProviderConfigAsync(
+            string providerId, CancellationToken cancellationToken)
+        {
+            var providerConfigManager = this.IfNotDeleted(
+                () => this.providerConfigManager.Value);
+            await providerConfigManager
+                .DeleteProviderConfigAsync(providerId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Gets an async enumerable to iterate or page through OIDC provider configurations
         /// starting from the specified page token. If the page token is null or unspecified,
         /// iteration starts from the first page. See
         /// <a href="https://googleapis.github.io/google-cloud-dotnet/docs/guides/page-streaming.html">
         /// Page Streaming</a> for more details on how to use this API.
         /// </summary>
-        /// <param name="options">The options to control the starting point and page size. Pass null
-        /// to list from the beginning with default settings.</param>
-        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, OidcProviderConfig}"/> instance.</returns>
+        /// <param name="options">The options to control the starting point and page size. Pass
+        /// null to list from the beginning with default settings.</param>
+        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, OidcProviderConfig}"/>
+        /// instance.</returns>
         public PagedAsyncEnumerable<AuthProviderConfigs<OidcProviderConfig>, OidcProviderConfig>
             ListOidcProviderConfigsAsync(ListProviderConfigsOptions options)
         {
@@ -1345,9 +1382,10 @@ namespace FirebaseAdmin.Auth
         /// <a href="https://googleapis.github.io/google-cloud-dotnet/docs/guides/page-streaming.html">
         /// Page Streaming</a> for more details on how to use this API.
         /// </summary>
-        /// <param name="options">The options to control the starting point and page size. Pass null
-        /// to list from the beginning with default settings.</param>
-        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, SamlProviderConfig}"/> instance.</returns>
+        /// <param name="options">The options to control the starting point and page size. Pass
+        /// null to list from the beginning with default settings.</param>
+        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, SamlProviderConfig}"/>
+        /// instance.</returns>
         public PagedAsyncEnumerable<AuthProviderConfigs<SamlProviderConfig>, SamlProviderConfig>
             ListSamlProviderConfigsAsync(ListProviderConfigsOptions options)
         {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
@@ -1260,7 +1260,7 @@ namespace FirebaseAdmin.Auth
         /// <summary>
         /// Creates a new auth provider configuration.
         /// </summary>
-        /// <returns>A task that completes with a <see cref="AuthProviderConfig"/>.</returns>
+        /// <returns>A task that completes with an <see cref="AuthProviderConfig"/>.</returns>
         /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
         /// invalid.</exception>
         /// <exception cref="FirebaseAuthException">If an unexpected error occurs while creating

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ProviderConfigClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ProviderConfigClient.cs
@@ -100,6 +100,18 @@ namespace FirebaseAdmin.Auth.Providers
                 .ConfigureAwait(false);
         }
 
+        internal async Task DeleteProviderConfigAsync(
+            ApiClient client, string providerId, CancellationToken cancellationToken)
+        {
+            var request = new HttpRequestMessage()
+            {
+                Method = HttpMethod.Delete,
+                RequestUri = BuildUri($"{this.ResourcePath}/{this.ValidateProviderId(providerId)}"),
+            };
+            await client.SendAndDeserializeAsync<object>(request, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         internal PagedAsyncEnumerable<AuthProviderConfigs<T>, T>
             ListProviderConfigsAsync(ApiClient client, ListProviderConfigsOptions options)
         {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ProviderConfigManager.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ProviderConfigManager.cs
@@ -100,6 +100,29 @@ namespace FirebaseAdmin.Auth.Providers
                 .ConfigureAwait(false);
         }
 
+        internal async Task DeleteProviderConfigAsync(
+            string providerId, CancellationToken cancellationToken)
+        {
+            providerId.ThrowIfNullOrEmpty(nameof(providerId));
+            if (providerId.StartsWith("oidc."))
+            {
+                await OidcProviderConfigClient.Instance
+                    .DeleteProviderConfigAsync(this.apiClient, providerId, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else if (providerId.StartsWith("saml."))
+            {
+                await SamlProviderConfigClient.Instance
+                    .DeleteProviderConfigAsync(this.apiClient, providerId, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                throw new ArgumentException(
+                    "Provider ID must have 'oidc.' or 'saml.' as the prefix.");
+            }
+        }
+
         internal PagedAsyncEnumerable<AuthProviderConfigs<OidcProviderConfig>, OidcProviderConfig>
             ListOidcProviderConfigsAsync(ListProviderConfigsOptions options)
         {


### PR DESCRIPTION
Implemented API for deleting auth provider configurations. This completes the IdP configuration management implementation. Integration tests will be added in a future PR.