### PR TITLE
chore: Added integration tests for SAML/OIDC IdP management

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAuthTest.cs
@@ -864,7 +864,7 @@ namespace FirebaseAdmin.IntegrationTests
         }
 
         /**
-         * The {@code batchDelete} endpoint is currently rate limited to 1qps. Use this test helper
+         * The <c>batchDelete</c> endpoint is currently rate limited to 1qps. Use this test helper
          * to ensure you don't run into quota exceeded errors.
          */
         // TODO(rsgowman): When/if the rate limit is relaxed, eliminate this helper.

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/OidcProviderConfigTest.cs
@@ -1,0 +1,172 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FirebaseAdmin.Auth;
+using FirebaseAdmin.Auth.Providers;
+using Xunit;
+
+namespace FirebaseAdmin.IntegrationTests
+{
+    [TestCaseOrderer(
+        "FirebaseAdmin.IntegrationTests.TestRankOrderer", "FirebaseAdmin.IntegrationTests")]
+    public class OidcProviderConfigTest : IClassFixture<OidcProviderConfigFixture>
+    {
+        private readonly OidcProviderConfigFixture fixture;
+
+        public OidcProviderConfigTest(OidcProviderConfigFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        [TestRank(0)]
+        public void CreateProviderConfig()
+        {
+            var config = this.fixture.ProviderConfig;
+
+            Assert.Equal("OIDC_DISPLAY_NAME", config.DisplayName);
+            Assert.True(config.Enabled);
+            Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
+            Assert.Equal("https://oidc.com/issuer", config.Issuer);
+        }
+
+        [Fact]
+        [TestRank(10)]
+        public async Task GetProviderConfig()
+        {
+            var config = await FirebaseAuth.DefaultInstance.GetOidcProviderConfigAsync(
+                this.fixture.ProviderId);
+
+            Assert.Equal("OIDC_DISPLAY_NAME", config.DisplayName);
+            Assert.True(config.Enabled);
+            Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
+            Assert.Equal("https://oidc.com/issuer", config.Issuer);
+        }
+
+        [Fact]
+        [TestRank(10)]
+        public async Task ListProviderConfig()
+        {
+            OidcProviderConfig config = null;
+
+            var pagedEnumerable = FirebaseAuth.DefaultInstance.ListOidcProviderConfigsAsync(null);
+            var enumerator = pagedEnumerable.GetEnumerator();
+            while (await enumerator.MoveNext())
+            {
+                if (enumerator.Current.ProviderId == this.fixture.ProviderId)
+                {
+                    config = enumerator.Current;
+                    break;
+                }
+            }
+
+            Assert.NotNull(config);
+            Assert.Equal("OIDC_DISPLAY_NAME", config.DisplayName);
+            Assert.True(config.Enabled);
+            Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
+            Assert.Equal("https://oidc.com/issuer", config.Issuer);
+        }
+
+        [Fact]
+        [TestRank(20)]
+        public async Task UpdateProviderConfig()
+        {
+            var args = new OidcProviderConfigArgs()
+            {
+                ProviderId = this.fixture.ProviderId,
+                DisplayName = "UPDATED_OIDC_DISPLAY_NAME",
+                Enabled = false,
+                ClientId = "UPDATED_OIDC_CLIENT_ID",
+                Issuer = "https://oidc.com/updated-issuer",
+            };
+
+            var config = await FirebaseAuth.DefaultInstance.UpdateProviderConfigAsync(args);
+
+            Assert.Equal("UPDATED_OIDC_DISPLAY_NAME", config.DisplayName);
+            Assert.False(config.Enabled);
+            Assert.Equal("UPDATED_OIDC_CLIENT_ID", config.ClientId);
+            Assert.Equal("https://oidc.com/updated-issuer", config.Issuer);
+        }
+
+        [Fact]
+        [TestRank(30)]
+        public async Task DeleteProviderConfig()
+        {
+            await FirebaseAuth.DefaultInstance.DeleteProviderConfigAsync(this.fixture.ProviderId);
+
+            this.fixture.ProviderConfig = null;
+
+            var exception = await Assert.ThrowsAsync<FirebaseAuthException>(
+                () => FirebaseAuth.DefaultInstance.GetOidcProviderConfigAsync(this.fixture.ProviderId));
+            Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
+            Assert.Equal(AuthErrorCode.ConfigurationNotFound, exception.AuthErrorCode);
+        }
+    }
+
+    /// <summary>
+    /// A fixture that allows reusing the same <see cref="AuthProviderConfig"/> instance across
+    /// multiple test cases.
+    /// </summary>
+    public abstract class ProviderConfigFixture<T> : IDisposable
+    where T : AuthProviderConfig
+    {
+        public string ProviderId { get; protected set; }
+
+        public T ProviderConfig { get; internal set; }
+
+        public void Dispose()
+        {
+            if (this.ProviderConfig != null)
+            {
+                FirebaseAuth.DefaultInstance
+                    .DeleteProviderConfigAsync(this.ProviderConfig.ProviderId)
+                    .Wait();
+            }
+        }
+
+        protected static string GetRandomIdentifier(int length = 10)
+        {
+            var random = new Random();
+            const string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+            var suffix = new string(Enumerable.Repeat(chars, length)
+                .Select(s => s[random.Next(s.Length)]).ToArray());
+            return $"id-{suffix}";
+        }
+    }
+
+    public class OidcProviderConfigFixture : ProviderConfigFixture<OidcProviderConfig>
+    {
+        public OidcProviderConfigFixture()
+        {
+            IntegrationTestUtils.EnsureDefaultApp();
+            var providerId = $"oidc.{GetRandomIdentifier()}";
+            var args = new OidcProviderConfigArgs()
+            {
+                ProviderId = providerId,
+                DisplayName = "OIDC_DISPLAY_NAME",
+                Enabled = true,
+                ClientId = "OIDC_CLIENT_ID",
+                Issuer = "https://oidc.com/issuer",
+            };
+            this.ProviderConfig = FirebaseAuth.DefaultInstance
+                .CreateProviderConfigAsync(args)
+                .Result;
+            this.ProviderId = providerId;
+        }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/OidcProviderConfigTest.cs
@@ -39,6 +39,7 @@ namespace FirebaseAdmin.IntegrationTests
         {
             var config = this.fixture.ProviderConfig;
 
+            Assert.Equal(this.fixture.ProviderId, config.ProviderId);
             Assert.Equal("OIDC_DISPLAY_NAME", config.DisplayName);
             Assert.True(config.Enabled);
             Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
@@ -52,6 +53,7 @@ namespace FirebaseAdmin.IntegrationTests
             var config = await FirebaseAuth.DefaultInstance.GetOidcProviderConfigAsync(
                 this.fixture.ProviderId);
 
+            Assert.Equal(this.fixture.ProviderId, config.ProviderId);
             Assert.Equal("OIDC_DISPLAY_NAME", config.DisplayName);
             Assert.True(config.Enabled);
             Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
@@ -76,6 +78,7 @@ namespace FirebaseAdmin.IntegrationTests
             }
 
             Assert.NotNull(config);
+            Assert.Equal(this.fixture.ProviderId, config.ProviderId);
             Assert.Equal("OIDC_DISPLAY_NAME", config.DisplayName);
             Assert.True(config.Enabled);
             Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
@@ -97,6 +100,7 @@ namespace FirebaseAdmin.IntegrationTests
 
             var config = await FirebaseAuth.DefaultInstance.UpdateProviderConfigAsync(args);
 
+            Assert.Equal(this.fixture.ProviderId, config.ProviderId);
             Assert.Equal("UPDATED_OIDC_DISPLAY_NAME", config.DisplayName);
             Assert.False(config.Enabled);
             Assert.Equal("UPDATED_OIDC_CLIENT_ID", config.ClientId);

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/SamlProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/SamlProviderConfigTest.cs
@@ -37,6 +37,7 @@ namespace FirebaseAdmin.IntegrationTests
         {
             var config = this.fixture.ProviderConfig;
 
+            Assert.Equal(this.fixture.ProviderId, config.ProviderId);
             Assert.Equal("SAML_DISPLAY_NAME", config.DisplayName);
             Assert.True(config.Enabled);
             Assert.Equal("IDP_ENTITY_ID", config.IdpEntityId);
@@ -53,6 +54,7 @@ namespace FirebaseAdmin.IntegrationTests
             var config = await FirebaseAuth.DefaultInstance.GetSamlProviderConfigAsync(
                 this.fixture.ProviderId);
 
+            Assert.Equal(this.fixture.ProviderId, config.ProviderId);
             Assert.Equal("SAML_DISPLAY_NAME", config.DisplayName);
             Assert.True(config.Enabled);
             Assert.Equal("IDP_ENTITY_ID", config.IdpEntityId);
@@ -80,6 +82,7 @@ namespace FirebaseAdmin.IntegrationTests
             }
 
             Assert.NotNull(config);
+            Assert.Equal(this.fixture.ProviderId, config.ProviderId);
             Assert.Equal("SAML_DISPLAY_NAME", config.DisplayName);
             Assert.True(config.Enabled);
             Assert.Equal("IDP_ENTITY_ID", config.IdpEntityId);
@@ -110,6 +113,7 @@ namespace FirebaseAdmin.IntegrationTests
 
             var config = await FirebaseAuth.DefaultInstance.UpdateProviderConfigAsync(args);
 
+            Assert.Equal(this.fixture.ProviderId, config.ProviderId);
             Assert.Equal("UPDATED_SAML_DISPLAY_NAME", config.DisplayName);
             Assert.False(config.Enabled);
             Assert.Equal("UPDATED_IDP_ENTITY_ID", config.IdpEntityId);

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/SamlProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/SamlProviderConfigTest.cs
@@ -1,0 +1,167 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FirebaseAdmin.Auth;
+using FirebaseAdmin.Auth.Providers;
+using Xunit;
+
+namespace FirebaseAdmin.IntegrationTests
+{
+    [TestCaseOrderer(
+        "FirebaseAdmin.IntegrationTests.TestRankOrderer", "FirebaseAdmin.IntegrationTests")]
+    public class SamlProviderConfigTest : IClassFixture<SamlProviderConfigFixture>
+    {
+        private readonly SamlProviderConfigFixture fixture;
+
+        public SamlProviderConfigTest(SamlProviderConfigFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        [TestRank(0)]
+        public void CreateProviderConfig()
+        {
+            var config = this.fixture.ProviderConfig;
+
+            Assert.Equal("SAML_DISPLAY_NAME", config.DisplayName);
+            Assert.True(config.Enabled);
+            Assert.Equal("IDP_ENTITY_ID", config.IdpEntityId);
+            Assert.Equal("https://example.com/login", config.SsoUrl);
+            Assert.Single(config.X509Certificates, SamlProviderConfigFixture.X509Certificates[0]);
+            Assert.Equal("RP_ENTITY_ID", config.RpEntityId);
+            Assert.Equal("https://projectId.firebaseapp.com/__/auth/handler", config.CallbackUrl);
+        }
+
+        [Fact]
+        [TestRank(10)]
+        public async Task GetProviderConfig()
+        {
+            var config = await FirebaseAuth.DefaultInstance.GetSamlProviderConfigAsync(
+                this.fixture.ProviderId);
+
+            Assert.Equal("SAML_DISPLAY_NAME", config.DisplayName);
+            Assert.True(config.Enabled);
+            Assert.Equal("IDP_ENTITY_ID", config.IdpEntityId);
+            Assert.Equal("https://example.com/login", config.SsoUrl);
+            Assert.Single(config.X509Certificates, SamlProviderConfigFixture.X509Certificates[0]);
+            Assert.Equal("RP_ENTITY_ID", config.RpEntityId);
+            Assert.Equal("https://projectId.firebaseapp.com/__/auth/handler", config.CallbackUrl);
+        }
+
+        [Fact]
+        [TestRank(10)]
+        public async Task ListProviderConfig()
+        {
+            SamlProviderConfig config = null;
+
+            var pagedEnumerable = FirebaseAuth.DefaultInstance.ListSamlProviderConfigsAsync(null);
+            var enumerator = pagedEnumerable.GetEnumerator();
+            while (await enumerator.MoveNext())
+            {
+                if (enumerator.Current.ProviderId == this.fixture.ProviderId)
+                {
+                    config = enumerator.Current;
+                    break;
+                }
+            }
+
+            Assert.NotNull(config);
+            Assert.Equal("SAML_DISPLAY_NAME", config.DisplayName);
+            Assert.True(config.Enabled);
+            Assert.Equal("IDP_ENTITY_ID", config.IdpEntityId);
+            Assert.Equal("https://example.com/login", config.SsoUrl);
+            Assert.Single(config.X509Certificates, SamlProviderConfigFixture.X509Certificates[0]);
+            Assert.Equal("RP_ENTITY_ID", config.RpEntityId);
+            Assert.Equal("https://projectId.firebaseapp.com/__/auth/handler", config.CallbackUrl);
+        }
+
+        [Fact]
+        [TestRank(20)]
+        public async Task UpdateProviderConfig()
+        {
+            var args = new SamlProviderConfigArgs()
+            {
+                ProviderId = this.fixture.ProviderId,
+                DisplayName = "UPDATED_SAML_DISPLAY_NAME",
+                Enabled = false,
+                IdpEntityId = "UPDATED_IDP_ENTITY_ID",
+                SsoUrl = "https://example.com/updated-login",
+                X509Certificates = new List<string>
+                {
+                    SamlProviderConfigFixture.X509Certificates[1],
+                },
+                RpEntityId = "UPDATED_RP_ENTITY_ID",
+                CallbackUrl = "https://projectId.firebaseapp.com/__/auth/updated-handler",
+            };
+
+            var config = await FirebaseAuth.DefaultInstance.UpdateProviderConfigAsync(args);
+
+            Assert.Equal("UPDATED_SAML_DISPLAY_NAME", config.DisplayName);
+            Assert.False(config.Enabled);
+            Assert.Equal("UPDATED_IDP_ENTITY_ID", config.IdpEntityId);
+            Assert.Equal("https://example.com/updated-login", config.SsoUrl);
+            Assert.Single(config.X509Certificates, SamlProviderConfigFixture.X509Certificates[1]);
+            Assert.Equal("UPDATED_RP_ENTITY_ID", config.RpEntityId);
+            Assert.Equal(
+                "https://projectId.firebaseapp.com/__/auth/updated-handler", config.CallbackUrl);
+        }
+
+        [Fact]
+        [TestRank(30)]
+        public async Task DeleteProviderConfig()
+        {
+            await FirebaseAuth.DefaultInstance.DeleteProviderConfigAsync(this.fixture.ProviderId);
+
+            this.fixture.ProviderConfig = null;
+
+            var exception = await Assert.ThrowsAsync<FirebaseAuthException>(
+                () => FirebaseAuth.DefaultInstance.GetSamlProviderConfigAsync(this.fixture.ProviderId));
+            Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
+            Assert.Equal(AuthErrorCode.ConfigurationNotFound, exception.AuthErrorCode);
+        }
+    }
+
+    public class SamlProviderConfigFixture : ProviderConfigFixture<SamlProviderConfig>
+    {
+        internal static readonly IList<string> X509Certificates = new List<string>()
+        {
+            "-----BEGIN CERTIFICATE-----\nMIICZjCCAc+gAwIBAgIBADANBgkqhkiG9w0BAQ0FADBQMQswCQYDVQQGEwJ1czEL\nMAkGA1UECAwCQ0ExDTALBgNVBAoMBEFjbWUxETAPBgNVBAMMCGFjbWUuY29tMRIw\nEAYDVQQHDAlTdW5ueXZhbGUwHhcNMTgxMjA2MDc1MTUxWhcNMjgxMjAzMDc1MTUx\nWjBQMQswCQYDVQQGEwJ1czELMAkGA1UECAwCQ0ExDTALBgNVBAoMBEFjbWUxETAP\nBgNVBAMMCGFjbWUuY29tMRIwEAYDVQQHDAlTdW5ueXZhbGUwgZ8wDQYJKoZIhvcN\nAQEBBQADgY0AMIGJAoGBAKphmggjiVgqMLXyzvI7cKphscIIQ+wcv7Dld6MD4aKv\n7Jqr8ltujMxBUeY4LFEKw8Terb01snYpDotfilaG6NxpF/GfVVmMalzwWp0mT8+H\nyzyPj89mRcozu17RwuooR6n1ofXjGcBE86lqC21UhA3WVgjPOLqB42rlE9gPnZLB\nAgMBAAGjUDBOMB0GA1UdDgQWBBS0iM7WnbCNOnieOP1HIA+Oz/ML+zAfBgNVHSME\nGDAWgBS0iM7WnbCNOnieOP1HIA+Oz/ML+zAMBgNVHRMEBTADAQH/MA0GCSqGSIb3\nDQEBDQUAA4GBAF3jBgS+wP+K/jTupEQur6iaqS4UvXd//d4vo1MV06oTLQMTz+rP\nOSMDNwxzfaOn6vgYLKP/Dcy9dSTnSzgxLAxfKvDQZA0vE3udsw0Bd245MmX4+GOp\nlbrN99XP1u+lFxCSdMUzvQ/jW4ysw/Nq4JdJ0gPAyPvL6Qi/3mQdIQwx\n-----END CERTIFICATE-----\n",
+            "-----BEGIN CERTIFICATE-----\nMIICZjCCAc+gAwIBAgIBADANBgkqhkiG9w0BAQ0FADBQMQswCQYDVQQGEwJ1czEL\nMAkGA1UECAwCQ0ExDTALBgNVBAoMBEFjbWUxETAPBgNVBAMMCGFjbWUuY29tMRIw\nEAYDVQQHDAlTdW5ueXZhbGUwHhcNMTgxMjA2MDc1ODE4WhcNMjgxMjAzMDc1ODE4\nWjBQMQswCQYDVQQGEwJ1czELMAkGA1UECAwCQ0ExDTALBgNVBAoMBEFjbWUxETAP\nBgNVBAMMCGFjbWUuY29tMRIwEAYDVQQHDAlTdW5ueXZhbGUwgZ8wDQYJKoZIhvcN\nAQEBBQADgY0AMIGJAoGBAKuzYKfDZGA6DJgQru3wNUqv+S0hMZfP/jbp8ou/8UKu\nrNeX7cfCgt3yxoGCJYKmF6t5mvo76JY0MWwA53BxeP/oyXmJ93uHG5mFRAsVAUKs\ncVVb0Xi6ujxZGVdDWFV696L0BNOoHTfXmac6IBoZQzNNK4n1AATqwo+z7a0pfRrJ\nAgMBAAGjUDBOMB0GA1UdDgQWBBSKmi/ZKMuLN0ES7/jPa7q7jAjPiDAfBgNVHSME\nGDAWgBSKmi/ZKMuLN0ES7/jPa7q7jAjPiDAMBgNVHRMEBTADAQH/MA0GCSqGSIb3\nDQEBDQUAA4GBAAg2a2kSn05NiUOuWOHwPUjW3wQRsGxPXtbhWMhmNdCfKKteM2+/\nLd/jz5F3qkOgGQ3UDgr3SHEoWhnLaJMF4a2tm6vL2rEIfPEK81KhTTRxSsAgMVbU\nJXBz1md6Ur0HlgQC7d1CHC8/xi2DDwHopLyxhogaZUxy9IaRxUEa2vJW\n-----END CERTIFICATE-----\n",
+        };
+
+        public SamlProviderConfigFixture()
+        {
+            IntegrationTestUtils.EnsureDefaultApp();
+            var providerId = $"saml.{GetRandomIdentifier()}";
+            var args = new SamlProviderConfigArgs()
+            {
+                ProviderId = providerId,
+                DisplayName = "SAML_DISPLAY_NAME",
+                Enabled = true,
+                IdpEntityId = "IDP_ENTITY_ID",
+                SsoUrl = "https://example.com/login",
+                X509Certificates = new List<string> { X509Certificates[0] },
+                RpEntityId = "RP_ENTITY_ID",
+                CallbackUrl = "https://projectId.firebaseapp.com/__/auth/handler",
+            };
+            this.ProviderConfig = FirebaseAuth.DefaultInstance
+                .CreateProviderConfigAsync(args)
+                .Result;
+            this.ProviderId = providerId;
+        }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/TestRankAttribute.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/TestRankAttribute.cs
@@ -1,0 +1,26 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace FirebaseAdmin.IntegrationTests
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class TestRankAttribute : Attribute
+    {
+        public TestRankAttribute(int rank) => this.Rank = rank;
+
+        internal int Rank { get; private set; }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/TestRankOrderer.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/TestRankOrderer.cs
@@ -1,0 +1,60 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace FirebaseAdmin.IntegrationTests
+{
+    /// <summary>
+    /// Use this test case orderer to order the execution of test cases by their
+    /// <see cref="TestRankAttribute"/>. Test cases with the same rank are ordered by their name.
+    /// Based on the example provided in the
+    /// <a href="https://docs.microsoft.com/en-us/dotnet/core/testing/order-unit-tests?pivots=xunit">
+    /// Microsoft documentation</a>.
+    /// </summary>
+    public class TestRankOrderer : ITestCaseOrderer
+    {
+        public IEnumerable<TTestCase> OrderTestCases<TTestCase>(IEnumerable<TTestCase> testCases)
+        where TTestCase : ITestCase
+        {
+            string testRankAttribute = typeof(TestRankAttribute).AssemblyQualifiedName;
+            var rankedMethods = new SortedDictionary<int, List<ITestCase>>();
+            foreach (var testCase in testCases)
+            {
+                int rank = testCase.TestMethod.Method.GetCustomAttributes(testRankAttribute)
+                    .FirstOrDefault()
+                    ?.GetNamedArgument<int>(nameof(TestRankAttribute.Rank)) ?? 0;
+                GetOrCreate(rankedMethods, rank).Add(testCase);
+            }
+
+            var orderedTests = rankedMethods.Keys.SelectMany((rank) =>
+                rankedMethods[rank].OrderBy((testCase) => testCase.TestMethod.Method.Name));
+            foreach (TTestCase testCase in orderedTests)
+            {
+                yield return testCase;
+            }
+        }
+
+        private static List<ITestCase> GetOrCreate(
+            IDictionary<int, List<ITestCase>> dictionary, int key)
+        {
+            return dictionary.TryGetValue(key, out List<ITestCase> result)
+                ? result
+                : (dictionary[key] = new List<ITestCase>());
+        }
+    }
+}


### PR DESCRIPTION
Using XUnit fixtures to reuse the same `AuthProviderConfig` across multiple test cases. Introduced a way to order the test cases within a class by applying a custom attribute.

Staging build triggered for verification.