### PR TITLE
fix(auth): Fixing the error response parsing of ImportUsersAsync()

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -162,25 +162,6 @@ namespace FirebaseAdmin.Auth.Tests
                 async () => await FirebaseAuth.DefaultInstance.SetCustomUserClaimsAsync("user1", customClaims));
         }
 
-        [Fact]
-        public async Task ImportUsersPasswordNoHash()
-        {
-            var args = new ImportUserRecordArgs()
-            {
-                Uid = "123",
-                Email = "example@gmail.com",
-                PasswordSalt = Encoding.ASCII.GetBytes("abc"),
-                PasswordHash = Encoding.ASCII.GetBytes("def"),
-            };
-
-            var usersLst = new List<ImportUserRecordArgs>()
-            {
-                args,
-            };
-            await Assert.ThrowsAsync<NullReferenceException>(
-                async () => await FirebaseAuth.DefaultInstance.ImportUsersAsync(usersLst));
-        }
-
         public void Dispose()
         {
             FirebaseApp.DeleteAll();

--- a/FirebaseAdmin/FirebaseAdmin/Auth/ErrorInfo.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/ErrorInfo.cs
@@ -13,15 +13,14 @@
 // limitations under the License.
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace FirebaseAdmin.Auth
 {
-    // TODO(rsgowman): This class is expected to also be used for the
-    // ImportUsersAsync() method... once that exists.
-
     /// <summary>
-    /// Represents an error encountered while deleting users via the
-    /// <see cref="FirebaseAuth.DeleteUsersAsync(IReadOnlyList{string})"/> API.
+    /// Represents an error encountered while performing a batch operation such as
+    /// <see cref="FirebaseAuth.ImportUsersAsync(IEnumerable{ImportUserRecordArgs})"/> or
+    /// <see cref="FirebaseAuth.DeleteUsersAsync(IReadOnlyList{string})"/>.
     /// </summary>
     public sealed class ErrorInfo
     {
@@ -31,15 +30,18 @@ namespace FirebaseAdmin.Auth
             this.Reason = reason;
         }
 
+        internal ErrorInfo() { }
+
         /// <summary>
-        /// Gets the index of the user that was unable to be deleted in the list passed to the
-        /// <see cref="FirebaseAuth.DeleteUsersAsync(IReadOnlyList{string})"/> method.
+        /// Gets the index of the entry that caused the error.
         /// </summary>
-        public int Index { get; }
+        [JsonProperty("index")]
+        public int Index { get; internal set; }
 
         /// <summary>
         /// Gets a string describing the error.
         /// </summary>
-        public string Reason { get; }
+        [JsonProperty("message")]
+        public string Reason { get; internal set; }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
@@ -812,7 +812,7 @@ namespace FirebaseAdmin.Auth
         {
           var request = new UserImportRequest(users, options);
           var userManager = this.IfNotDeleted(() => this.userManager.Value);
-          return await userManager.ImportUsersAsync(request, cancellationToken);
+          return await userManager.ImportUsersAsync(users, options, cancellationToken);
         }
 
         /// <summary>

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseUserManager.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseUserManager.cs
@@ -230,23 +230,14 @@ namespace FirebaseAdmin.Auth
         }
 
         internal async Task<UserImportResult> ImportUsersAsync(
-          UserImportRequest request,
-          CancellationToken cancellationToken)
+            IEnumerable<ImportUserRecordArgs> users,
+            UserImportOptions options,
+            CancellationToken cancellationToken)
         {
-            if (request == null)
-            {
-                throw new ArgumentNullException("The UserImportRequest request should not be null");
-            }
-
+            var request = new UserImportRequest(users, options);
             var response = await this.PostAndDeserializeAsync<UploadAccountResponse>(
                 "accounts:batchCreate", request, cancellationToken).ConfigureAwait(false);
-            var uploadAccountResponse = response.Result;
-            if (uploadAccountResponse == null)
-            {
-                throw new FirebaseAuthException(ErrorCode.Internal, "Failed to import users.");
-            }
-
-            return new UserImportResult(request.GetUsersCount(), uploadAccountResponse.Errors);
+            return new UserImportResult(request.UserCount, response.Result.Errors);
         }
 
         /// <summary>
@@ -439,11 +430,8 @@ namespace FirebaseAdmin.Auth
         /// </summary>
         internal sealed class UploadAccountResponse
         {
-            /// <summary>
-            /// Gets the list of errors populated after a user import request by the identity toolkit.
-            /// </summary>
             [JsonProperty("error")]
-            public IReadOnlyList<ErrorInfo> Errors { get; }
+            internal List<ErrorInfo> Errors { get; set; }
         }
 
         /// <summary>

--- a/FirebaseAdmin/FirebaseAdmin/Auth/ImportUserRecordArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/ImportUserRecordArgs.cs
@@ -21,8 +21,8 @@ namespace FirebaseAdmin.Auth
 {
     /// <summary>
     /// Represents a user account to be imported to Firebase Auth via the
-    /// <a cref="o:FirebaseAuth.ImportUsersAsync">FirebaseAuth.ImportUsersAsync</a> API. Must contain at least a
-    /// user ID string.
+    /// <see cref="FirebaseAuth.ImportUsersAsync(IEnumerable{ImportUserRecordArgs})"/> API. Must
+    /// contain at least a user ID string.
     /// </summary>
     public sealed class ImportUserRecordArgs
     {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/UserImportHash.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/UserImportHash.cs
@@ -50,13 +50,8 @@ namespace FirebaseAdmin.Auth
         /// Retrieves the properties of the chosen hashing algorithm.
         /// </summary>
         /// <returns>Dictionary containing the specified properties of the hashing algorithm.</returns>
-        internal IReadOnlyDictionary<string, object> GetProperties()
+        internal Dictionary<string, object> GetProperties()
         {
-            if (string.IsNullOrEmpty(this.hashName))
-            {
-                throw new ArgumentException("User import hash name must not be null or empty.");
-            }
-
             var options = this.GetHashConfiguration();
             var properties = new Dictionary<string, object>();
             foreach (var entry in options)

--- a/FirebaseAdmin/FirebaseAdmin/Auth/UserImportOptions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/UserImportOptions.cs
@@ -33,7 +33,7 @@ namespace FirebaseAdmin.Auth
         /// Retrieves properties of the password hashing algorithm.
         /// </summary>
         /// <returns>Dictionary containing key/values for password hashing properties.</returns>
-        internal IReadOnlyDictionary<string, object> GetHashProperties()
+        internal Dictionary<string, object> GetHashProperties()
         {
             if (this.Hash == null)
             {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/UserImportRequest.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/UserImportRequest.cs
@@ -33,38 +33,32 @@ namespace FirebaseAdmin.Auth
         /// <c>MaxImportUsers</c>), and a valid <see cref="UserImportHash"/> is supplied when a
         /// password is provided to at least one of the users.
         /// </summary>
-        /// <param name="usersToImport"> List of users to be imported.</param>
-        /// <param name="options"> Options for user imports, see
-        /// <a cref="UserImportOptions">UserImportOptions</a>.</param>
-        /// <returns>Dictionary containing key/values for the password hashing algorithm.</returns>
-        public UserImportRequest(
-            IEnumerable<ImportUserRecordArgs> usersToImport,
-            UserImportOptions options)
+        /// <param name="usersToImport">List of users to be imported.</param>
+        /// <param name="options">Options for user imports. Possibly null.</param>
+        internal UserImportRequest(
+            IEnumerable<ImportUserRecordArgs> usersToImport, UserImportOptions options)
         {
-            if (usersToImport.Count() == 0)
+            if (usersToImport == null || usersToImport.Count() == 0)
             {
-                throw new ArgumentException("users must not be empty");
+                throw new ArgumentException("Users must not be null or empty.");
             }
 
             if (usersToImport.Count() > MaxImportUsers)
             {
-                throw new ArgumentException("users list must not contain more than"
-                    + $" {MaxImportUsers} items");
+                throw new ArgumentException(
+                    $"Users list must not contain more than {MaxImportUsers} items.");
             }
 
             this.Users = usersToImport.Select((user) => user.ToRequest());
-            var hasPassword = usersToImport.Any((user) => user.HasPassword());
-
-            if (hasPassword)
+            if (usersToImport.Any((user) => user.HasPassword()))
             {
                 if (options?.Hash == null)
                 {
-                    throw new ArgumentNullException("UserImportHash option is required when at"
-                        + " least one user has a password. Provide a UserImportHash via the"
-                        + " Hash setter.");
+                    throw new ArgumentException(
+                        "UserImportHash option is required when at least one user has a password.");
                 }
 
-                this.HashProperties = (Dictionary<string, object>)options.GetHashProperties();
+                this.HashProperties = options.GetHashProperties();
             }
         }
 
@@ -72,20 +66,16 @@ namespace FirebaseAdmin.Auth
         internal IEnumerable<ImportUserRecordArgs.Request> Users { get; private set; }
 
         /// <summary>
+        /// Gets the number of users based on the constructor parameter.
+        /// </summary>
+        [JsonIgnore]
+        internal int UserCount => this.Users.Count();
+
+        /// <summary>
         /// Gets or sets JSON extension data for putting hashing properties at the root of the
         /// JSON serialized object.
         /// </summary>
-        /// <returns>Dictionary containing key/values for the password hashing algorithm.</returns>
         [JsonExtensionData]
-        private Dictionary<string, object> HashProperties { get; set; }
-
-        /// <summary>
-        /// Retrives the number of users based on the constructor parameter.
-        /// </summary>
-        /// <returns>Number of users.</returns>
-        public int GetUsersCount()
-        {
-            return this.Users.Count();
-        }
+        internal Dictionary<string, object> HashProperties { get; set; }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/UserImportResult.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/UserImportResult.cs
@@ -18,45 +18,38 @@ namespace FirebaseAdmin.Auth
 {
     /// <summary>
     /// Represents the result of the
-    /// <a cref="o:FirebaseAuth.ImportUsersAsync">FirebaseAuth.ImportUsersAsync</a> API.
+    /// <see cref="FirebaseAuth.ImportUsersAsync(IEnumerable{ImportUserRecordArgs})"/> API.
     /// </summary>
     public sealed class UserImportResult
     {
         private readonly int users;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="UserImportResult"/> class based on supplied
-        /// users and <a cref="FirebaseUserManager.UploadAccountResponse">UploadAccountResponse</a> objects.
+        /// Initializes a new instance of the <see cref="UserImportResult"/> class.
         /// </summary>
-        /// <param name="users"> The number of users.</param>
-        /// <param name="errors"> Any errors generated from the post request.</param>
+        /// <param name="users">The number of users that was included in the input import
+        /// request.</param>
+        /// <param name="errors">Any errors encountered while importing users. Possibly
+        /// null.</param>
         internal UserImportResult(int users, IReadOnlyList<ErrorInfo> errors)
         {
-            this.Errors = errors;
             this.users = users;
+            this.Errors = errors ?? new List<ErrorInfo>();
         }
 
         /// <summary>
-        /// Gets errors associated with a user import.
+        /// Gets errors associated with a user import. Empty list if there were no errors.
         /// </summary>
-        public IReadOnlyList<ErrorInfo> Errors { get; private set; }
+        public IReadOnlyList<ErrorInfo> Errors { get; }
 
         /// <summary>
         /// Gets the number of users that were imported successfully.
         /// </summary>
-        /// <returns>Number of users successfully imported (possibly zero).</returns>
-        public int SuccessCount
-        {
-            get => this.users - this.FailureCount;
-        }
+        public int SuccessCount => this.users - this.FailureCount;
 
         /// <summary>
         /// Gets the number of users that failed to be imported.
         /// </summary>
-        /// <returns>Number of users that resulted in import failures (possibly zero).</returns>
-        public int FailureCount
-        {
-            get => this.Errors?.Count ?? 0;
-        }
+        public int FailureCount => this.Errors?.Count ?? 0;
     }
 }


### PR DESCRIPTION
I was trying to improve the test coverage of this API, and in the processes uncovered several bugs and documentation errors. Specifically the current implementation does not correctly handle user import error responses due to issues in response unmarshaling (missing setters and constructors). I've addressed these issues here.

RELEASE NOTE: Fixed a bug in the `ImportUsersAsync()` that was preventing the correct handling of user import errors.