### PR TITLE
feat(auth): Support for verifying tenant-scoped session cookies

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
@@ -66,6 +66,12 @@ namespace FirebaseAdmin.Auth.Tests
                 args.IdTokenVerifier = new Lazy<FirebaseTokenVerifier>(
                     this.CreateIdTokenVerifier());
             }
+
+            if (options.SessionCookieVerifier)
+            {
+                args.SessionCookieVerifier = new Lazy<FirebaseTokenVerifier>(
+                    this.CreateSessionCookieVerifier());
+            }
         }
 
         private FirebaseUserManager CreateUserManager(TestOptions options)
@@ -84,6 +90,12 @@ namespace FirebaseAdmin.Auth.Tests
         private FirebaseTokenVerifier CreateIdTokenVerifier()
         {
             return FirebaseTokenVerifier.CreateIdTokenVerifier(
+                this.ProjectId, this.KeySource, this.Clock, this.TenantId);
+        }
+
+        private FirebaseTokenVerifier CreateSessionCookieVerifier()
+        {
+            return FirebaseTokenVerifier.CreateSessionCookieVerifier(
                 this.ProjectId, this.KeySource, this.Clock, this.TenantId);
         }
     }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -62,10 +62,9 @@ namespace FirebaseAdmin.Auth.Tests
             app.Delete();
 
             Assert.Throws<InvalidOperationException>(() => auth.TokenFactory);
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await auth.VerifyIdTokenAsync("user"));
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await auth.SetCustomUserClaimsAsync("user", null));
+            Assert.Throws<InvalidOperationException>(() => auth.IdTokenVerifier);
+            Assert.Throws<InvalidOperationException>(() => auth.SessionCookieVerifier);
+            Assert.Throws<InvalidOperationException>(() => auth.UserManager);
             await Assert.ThrowsAsync<InvalidOperationException>(
                 async () => await auth.GetOidcProviderConfigAsync("oidc.provider"));
             Assert.Throws<InvalidOperationException>(() => auth.TenantManager);
@@ -84,6 +83,7 @@ namespace FirebaseAdmin.Auth.Tests
 
             Assert.Null(auth.TokenFactory.TenantId);
             Assert.Null(auth.IdTokenVerifier.TenantId);
+            Assert.Null(auth.SessionCookieVerifier.TenantId);
             Assert.Null(auth.UserManager.TenantId);
         }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/JwtTestUtils.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/JwtTestUtils.cs
@@ -79,13 +79,6 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
             };
         }
 
-        public static string RevocationCheckRequestPath(
-            string expectedSuffix, string tenantId = null)
-        {
-            var tenantInfo = tenantId != null ? $"/tenants/{tenantId}" : string.Empty;
-            return $"/v1/projects/{ProjectId}{tenantInfo}/{expectedSuffix}";
-        }
-
         public static void AssertRevocationCheckRequest(string tenantId, Uri uri)
         {
             var tenantInfo = tenantId != null ? $"/tenants/{tenantId}" : string.Empty;

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/JwtTestUtils.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/JwtTestUtils.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -19,17 +20,78 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using FirebaseAdmin.Auth.Tests;
+using FirebaseAdmin.Tests;
+using FirebaseAdmin.Util;
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Util;
+using Xunit;
 
 namespace FirebaseAdmin.Auth.Jwt.Tests
 {
     public sealed class JwtTestUtils
     {
+        internal const string ProjectId = "test-project";
+
+        internal static readonly IClock Clock = new MockClock();
+
         internal static readonly IPublicKeySource DefaultKeySource = new FileSystemPublicKeySource(
             "./resources/public_cert.pem");
 
         internal static readonly ISigner DefaultSigner = CreateTestSigner(
             "./resources/service_account.json");
+
+        public static AuthBuilder AuthBuilderForTokenVerification(string tenantId = null)
+        {
+            return new AuthBuilder
+            {
+                ProjectId = ProjectId,
+                Clock = Clock,
+                KeySource = DefaultKeySource,
+                RetryOptions = RetryOptions.NoBackOff,
+                TenantId = tenantId,
+            };
+        }
+
+        public static MockTokenBuilder IdTokenBuilder(string tenantId = null)
+        {
+            return new MockTokenBuilder
+            {
+                ProjectId = ProjectId,
+                Clock = Clock,
+                Signer = JwtTestUtils.DefaultSigner,
+                IssuerPrefix = "https://securetoken.google.com",
+                Uid = "testuser",
+                TenantId = tenantId,
+            };
+        }
+
+        public static MockTokenBuilder SessionCookieBuilder(string tenantId = null)
+        {
+            return new MockTokenBuilder
+            {
+                ProjectId = ProjectId,
+                Clock = Clock,
+                Signer = JwtTestUtils.DefaultSigner,
+                IssuerPrefix = "https://session.firebase.google.com",
+                Uid = "testuser",
+                TenantId = tenantId,
+            };
+        }
+
+        public static string RevocationCheckRequestPath(
+            string expectedSuffix, string tenantId = null)
+        {
+            var tenantInfo = tenantId != null ? $"/tenants/{tenantId}" : string.Empty;
+            return $"/v1/projects/{ProjectId}{tenantInfo}/{expectedSuffix}";
+        }
+
+        public static void AssertRevocationCheckRequest(string tenantId, Uri uri)
+        {
+            var tenantInfo = tenantId != null ? $"/tenants/{tenantId}" : string.Empty;
+            var expectedPath = $"/v1/projects/{ProjectId}{tenantInfo}/accounts:lookup";
+            Assert.Equal(expectedPath, uri.PathAndQuery);
+        }
 
         private static ISigner CreateTestSigner(string filePath)
         {

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
@@ -31,6 +31,9 @@ namespace FirebaseAdmin.Auth.Multitenancy
             app.Delete();
 
             Assert.Throws<InvalidOperationException>(() => auth.TokenFactory);
+            Assert.Throws<InvalidOperationException>(() => auth.IdTokenVerifier);
+            Assert.Throws<InvalidOperationException>(() => auth.SessionCookieVerifier);
+            Assert.Throws<InvalidOperationException>(() => auth.UserManager);
         }
 
         [Fact]
@@ -43,6 +46,7 @@ namespace FirebaseAdmin.Auth.Multitenancy
             Assert.Equal(MockTenantId, auth.TenantId);
             Assert.Equal(MockTenantId, auth.TokenFactory.TenantId);
             Assert.Equal(MockTenantId, auth.IdTokenVerifier.TenantId);
+            Assert.Equal(MockTenantId, auth.SessionCookieVerifier.TenantId);
             Assert.Equal(MockTenantId, auth.UserManager.TenantId);
         }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/TestOptions.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/TestOptions.cs
@@ -26,5 +26,7 @@ namespace FirebaseAdmin.Auth.Tests
         public HttpMessageHandler UserManagerRequestHandler { get; set; }
 
         public bool IdTokenVerifier { get; set; }
+
+        public bool SessionCookieVerifier { get; set; }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
@@ -126,7 +126,8 @@ namespace FirebaseAdmin.Auth.Jwt
             return new FirebaseTokenVerifier(args);
         }
 
-        internal static FirebaseTokenVerifier CreateSessionCookieVerifier(FirebaseApp app)
+        internal static FirebaseTokenVerifier CreateSessionCookieVerifier(
+            FirebaseApp app, string tenantId = null)
         {
             var projectId = app.GetProjectId();
             if (string.IsNullOrEmpty(projectId))
@@ -137,7 +138,28 @@ namespace FirebaseAdmin.Auth.Jwt
 
             var keySource = new HttpPublicKeySource(
                 SessionCookieCertUrl, SystemClock.Default, app.Options.HttpClientFactory);
-            var args = FirebaseTokenVerifierArgs.ForSessionCookies(projectId, keySource);
+            return CreateSessionCookieVerifier(projectId, keySource, tenantId: tenantId);
+        }
+
+        internal static FirebaseTokenVerifier CreateSessionCookieVerifier(
+            string projectId,
+            IPublicKeySource keySource,
+            IClock clock = null,
+            string tenantId = null)
+        {
+            var args = new FirebaseTokenVerifierArgs()
+            {
+                ProjectId = projectId,
+                TenantId = tenantId,
+                ShortName = "session cookie",
+                Operation = "VerifySessionCookieAsync()",
+                Url = "https://firebase.google.com/docs/auth/admin/manage-cookies",
+                Issuer = "https://session.firebase.google.com/",
+                Clock = clock,
+                PublicKeySource = keySource,
+                InvalidTokenCode = AuthErrorCode.InvalidSessionCookie,
+                ExpiredTokenCode = AuthErrorCode.ExpiredSessionCookie,
+            };
             return new FirebaseTokenVerifier(args);
         }
 

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifierArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifierArgs.cs
@@ -37,22 +37,5 @@ namespace FirebaseAdmin.Auth.Jwt
         public AuthErrorCode InvalidTokenCode { get; set; }
 
         public AuthErrorCode ExpiredTokenCode { get; set; }
-
-        internal static FirebaseTokenVerifierArgs ForSessionCookies(
-            string projectId, IPublicKeySource keySource, IClock clock = null)
-        {
-            return new FirebaseTokenVerifierArgs()
-            {
-                ProjectId = projectId,
-                ShortName = "session cookie",
-                Operation = "VerifySessionCookieAsync()",
-                Url = "https://firebase.google.com/docs/auth/admin/manage-cookies",
-                Issuer = "https://session.firebase.google.com/",
-                Clock = clock ?? SystemClock.Default,
-                PublicKeySource = keySource,
-                InvalidTokenCode = AuthErrorCode.InvalidSessionCookie,
-                ExpiredTokenCode = AuthErrorCode.ExpiredSessionCookie,
-            };
-        }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
@@ -47,6 +47,8 @@ namespace FirebaseAdmin.Auth.Multitenancy
                     () => FirebaseTokenFactory.Create(app, tenantId), true),
                 IdTokenVerifier = new Lazy<FirebaseTokenVerifier>(
                     () => FirebaseTokenVerifier.CreateIdTokenVerifier(app, tenantId), true),
+                SessionCookieVerifier = new Lazy<FirebaseTokenVerifier>(
+                    () => FirebaseTokenVerifier.CreateSessionCookieVerifier(app, tenantId), true),
                 UserManager = new Lazy<FirebaseUserManager>(
                     () => FirebaseUserManager.Create(app, tenantId), true),
             };
@@ -63,6 +65,7 @@ namespace FirebaseAdmin.Auth.Multitenancy
                 {
                     TokenFactory = new Lazy<FirebaseTokenFactory>(),
                     IdTokenVerifier = new Lazy<FirebaseTokenVerifier>(),
+                    SessionCookieVerifier = new Lazy<FirebaseTokenVerifier>(),
                     UserManager = new Lazy<FirebaseUserManager>(),
                     TenantId = tenantId,
                 };


### PR DESCRIPTION
* Moved `VerifySessionCookieAsync()` APIs to `AbstractFirebaseAuth`.
* Added support for initializing test session cookie verifiers via `AuthBuilder` and `TestOptions`.