### PR TITLE
feat(auth): Support for creating tenant-scoped session cookies

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Auth/AbstractFirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/AbstractFirebaseAuth.cs
@@ -979,6 +979,39 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
+        /// Creates a new Firebase session cookie from the given ID token and options. The returned JWT can
+        /// be set as a server-side session cookie with a custom cookie policy.
+        /// </summary>
+        /// <exception cref="FirebaseAuthException">If an error occurs while creating the cookie.</exception>
+        /// <param name="idToken">The Firebase ID token to exchange for a session cookie.</param>
+        /// <param name="options">Additional options required to create the cookie.</param>
+        /// <returns>A task that completes with the Firebase session cookie.</returns>
+        public async Task<string> CreateSessionCookieAsync(
+            string idToken, SessionCookieOptions options)
+        {
+            return await this.CreateSessionCookieAsync(idToken, options, default(CancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new Firebase session cookie from the given ID token and options. The returned JWT can
+        /// be set as a server-side session cookie with a custom cookie policy.
+        /// </summary>
+        /// <exception cref="FirebaseAuthException">If an error occurs while creating the cookie.</exception>
+        /// <param name="idToken">The Firebase ID token to exchange for a session cookie.</param>
+        /// <param name="options">Additional options required to create the cookie.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        /// <returns>A task that completes with the Firebase session cookie.</returns>
+        public virtual async Task<string> CreateSessionCookieAsync(
+            string idToken, SessionCookieOptions options, CancellationToken cancellationToken)
+        {
+            return await this.UserManager
+                .CreateSessionCookieAsync(idToken, options, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Parses and verifies a Firebase session cookie.
         ///
         /// <para>See <a href="https://firebase.google.com/docs/auth/admin/manage-cookies">Manage

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
@@ -84,39 +84,6 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
-        /// Creates a new Firebase session cookie from the given ID token and options. The returned JWT can
-        /// be set as a server-side session cookie with a custom cookie policy.
-        /// </summary>
-        /// <exception cref="FirebaseAuthException">If an error occurs while creating the cookie.</exception>
-        /// <param name="idToken">The Firebase ID token to exchange for a session cookie.</param>
-        /// <param name="options">Additional options required to create the cookie.</param>
-        /// <returns>A task that completes with the Firebase session cookie.</returns>
-        public async Task<string> CreateSessionCookieAsync(
-            string idToken, SessionCookieOptions options)
-        {
-            return await this.CreateSessionCookieAsync(idToken, options, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Creates a new Firebase session cookie from the given ID token and options. The returned JWT can
-        /// be set as a server-side session cookie with a custom cookie policy.
-        /// </summary>
-        /// <exception cref="FirebaseAuthException">If an error occurs while creating the cookie.</exception>
-        /// <param name="idToken">The Firebase ID token to exchange for a session cookie.</param>
-        /// <param name="options">Additional options required to create the cookie.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        /// <returns>A task that completes with the Firebase session cookie.</returns>
-        public async Task<string> CreateSessionCookieAsync(
-            string idToken, SessionCookieOptions options, CancellationToken cancellationToken)
-        {
-            return await this.UserManager
-                .CreateSessionCookieAsync(idToken, options, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Looks up an OIDC auth provider configuration by the provided ID.
         /// </summary>
         /// <returns>A task that completes with a <see cref="OidcProviderConfig"/>.</returns>

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
@@ -41,16 +41,7 @@ namespace FirebaseAdmin.Auth.Multitenancy
         /// </summary>
         public string TenantId { get; }
 
-        /// <summary>
-        /// Creates a new Firebase session cookie from the given ID token and options. The returned JWT can
-        /// be set as a server-side session cookie with a custom cookie policy.
-        /// </summary>
-        /// <exception cref="FirebaseAuthException">If an error occurs while creating the cookie.</exception>
-        /// <param name="idToken">The Firebase ID token to exchange for a session cookie.</param>
-        /// <param name="options">Additional options required to create the cookie.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        /// <returns>A task that completes with the Firebase session cookie.</returns>
+        /// <inheritdoc/>
         public override async Task<string> CreateSessionCookieAsync(
             string idToken, SessionCookieOptions options, CancellationToken cancellationToken)
         {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 using FirebaseAdmin.Auth.Jwt;
+using Google.Apis.Util;
 
 namespace FirebaseAdmin.Auth.Multitenancy
 {
@@ -37,6 +40,26 @@ namespace FirebaseAdmin.Auth.Multitenancy
         /// Gets the tenant ID associated with this instance.
         /// </summary>
         public string TenantId { get; }
+
+        /// <summary>
+        /// Creates a new Firebase session cookie from the given ID token and options. The returned JWT can
+        /// be set as a server-side session cookie with a custom cookie policy.
+        /// </summary>
+        /// <exception cref="FirebaseAuthException">If an error occurs while creating the cookie.</exception>
+        /// <param name="idToken">The Firebase ID token to exchange for a session cookie.</param>
+        /// <param name="options">Additional options required to create the cookie.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        /// <returns>A task that completes with the Firebase session cookie.</returns>
+        public override async Task<string> CreateSessionCookieAsync(
+            string idToken, SessionCookieOptions options, CancellationToken cancellationToken)
+        {
+            // As a minor optimization, validate options here before calling VerifyIdToken().
+            options.ThrowIfNull(nameof(options)).CopyAndValidate();
+            await this.VerifyIdTokenAsync(idToken, cancellationToken);
+            return await base.CreateSessionCookieAsync(idToken, options, cancellationToken)
+                .ConfigureAwait(false);
+        }
 
         internal static TenantAwareFirebaseAuth Create(FirebaseApp app, string tenantId)
         {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/SessionCookieOptions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/SessionCookieOptions.cs
@@ -17,7 +17,9 @@ using System;
 namespace FirebaseAdmin.Auth
 {
     /// <summary>
-    /// Options for the <see cref="FirebaseAuth.CreateSessionCookieAsync(string, SessionCookieOptions)"/> API.
+    /// Options for the
+    /// <see cref="AbstractFirebaseAuth.CreateSessionCookieAsync(string, SessionCookieOptions)"/>
+    /// API.
     /// </summary>
     public sealed class SessionCookieOptions
     {


### PR DESCRIPTION
* Moved `CreateSessionCookieAsync()` APIs to `AbstractFirebaseAuth`.
* Overrode `CreateSessionCookieAsync()` in `TenantAwareFirebaseAuth` to perform an ID token verification locally before creating the session cookie. This ensures the tenant ID of the input ID token matches the client.