### PR TITLE
feat(auth): Tenant-aware provider config management

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
@@ -15,6 +15,7 @@
 using System;
 using FirebaseAdmin.Auth.Jwt;
 using FirebaseAdmin.Auth.Multitenancy;
+using FirebaseAdmin.Auth.Providers;
 using FirebaseAdmin.Tests;
 using FirebaseAdmin.Util;
 using Google.Apis.Util;
@@ -61,6 +62,12 @@ namespace FirebaseAdmin.Auth.Tests
                     this.CreateUserManager(options));
             }
 
+            if (options.ProviderConfigRequestHandler != null)
+            {
+                args.ProviderConfigManager = new Lazy<ProviderConfigManager>(
+                    this.CreateProviderConfigManager(options));
+            }
+
             if (options.IdTokenVerifier)
             {
                 args.IdTokenVerifier = new Lazy<FirebaseTokenVerifier>(
@@ -85,6 +92,18 @@ namespace FirebaseAdmin.Auth.Tests
                 TenantId = this.TenantId,
             };
             return new FirebaseUserManager(args);
+        }
+
+        private ProviderConfigManager CreateProviderConfigManager(TestOptions options)
+        {
+            var args = new ProviderConfigManager.Args
+            {
+                RetryOptions = RetryOptions.NoBackOff,
+                ProjectId = this.ProjectId,
+                ClientFactory = new MockHttpClientFactory(options.ProviderConfigRequestHandler),
+                TenantId = this.TenantId,
+            };
+            return new ProviderConfigManager(args);
         }
 
         private FirebaseTokenVerifier CreateIdTokenVerifier()

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -54,7 +54,7 @@ namespace FirebaseAdmin.Auth.Tests
         }
 
         [Fact]
-        public async Task UseAfterDelete()
+        public void UseAfterDelete()
         {
             var app = FirebaseApp.Create(new AppOptions() { Credential = MockCredential });
             var auth = FirebaseAuth.DefaultInstance;
@@ -65,8 +65,7 @@ namespace FirebaseAdmin.Auth.Tests
             Assert.Throws<InvalidOperationException>(() => auth.IdTokenVerifier);
             Assert.Throws<InvalidOperationException>(() => auth.SessionCookieVerifier);
             Assert.Throws<InvalidOperationException>(() => auth.UserManager);
-            await Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await auth.GetOidcProviderConfigAsync("oidc.provider"));
+            Assert.Throws<InvalidOperationException>(() => auth.ProviderConfigManager);
             Assert.Throws<InvalidOperationException>(() => auth.TenantManager);
         }
 
@@ -97,6 +96,19 @@ namespace FirebaseAdmin.Auth.Tests
 
             Assert.Equal(
                 "Must initialize FirebaseApp with a project ID to manage users.",
+                ex.Message);
+        }
+
+        [Fact]
+        public void ProviderConfigManagerNoProjectId()
+        {
+            FirebaseApp.Create(new AppOptions() { Credential = MockCredential });
+
+            var ex = Assert.Throws<ArgumentException>(
+                () => FirebaseAuth.DefaultInstance.ProviderConfigManager);
+
+            Assert.Equal(
+                "Must initialize FirebaseApp with a project ID to manage provider configurations.",
                 ex.Message);
         }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
@@ -34,6 +34,7 @@ namespace FirebaseAdmin.Auth.Multitenancy
             Assert.Throws<InvalidOperationException>(() => auth.IdTokenVerifier);
             Assert.Throws<InvalidOperationException>(() => auth.SessionCookieVerifier);
             Assert.Throws<InvalidOperationException>(() => auth.UserManager);
+            Assert.Throws<InvalidOperationException>(() => auth.ProviderConfigManager);
         }
 
         [Fact]
@@ -48,6 +49,7 @@ namespace FirebaseAdmin.Auth.Multitenancy
             Assert.Equal(MockTenantId, auth.IdTokenVerifier.TenantId);
             Assert.Equal(MockTenantId, auth.SessionCookieVerifier.TenantId);
             Assert.Equal(MockTenantId, auth.UserManager.TenantId);
+            Assert.Equal(MockTenantId, auth.ProviderConfigManager.TenantId);
         }
 
         public void Dispose()

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/TestOptions.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/TestOptions.cs
@@ -25,6 +25,8 @@ namespace FirebaseAdmin.Auth.Tests
     {
         public HttpMessageHandler UserManagerRequestHandler { get; set; }
 
+        public HttpMessageHandler ProviderConfigRequestHandler { get; set; }
+
         public bool IdTokenVerifier { get; set; }
 
         public bool SessionCookieVerifier { get; set; }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/AbstractFirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/AbstractFirebaseAuth.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FirebaseAdmin.Auth.Jwt;
+using FirebaseAdmin.Auth.Providers;
 using Google.Api.Gax;
 using Google.Apis.Util;
 
@@ -33,6 +34,7 @@ namespace FirebaseAdmin.Auth
         private readonly Lazy<FirebaseTokenVerifier> idTokenVerifier;
         private readonly Lazy<FirebaseTokenVerifier> sessionCookieVerifier;
         private readonly Lazy<FirebaseUserManager> userManager;
+        private readonly Lazy<ProviderConfigManager> providerConfigManager;
         private bool deleted;
 
         internal AbstractFirebaseAuth(Args args)
@@ -43,6 +45,8 @@ namespace FirebaseAdmin.Auth
             this.sessionCookieVerifier = args.SessionCookieVerifier.ThrowIfNull(
                 nameof(args.SessionCookieVerifier));
             this.userManager = args.UserManager.ThrowIfNull(nameof(args.UserManager));
+            this.providerConfigManager = args.ProviderConfigManager.ThrowIfNull(
+                nameof(args.ProviderConfigManager));
         }
 
         internal FirebaseTokenFactory TokenFactory =>
@@ -56,6 +60,9 @@ namespace FirebaseAdmin.Auth
 
         internal FirebaseUserManager UserManager =>
             this.IfNotDeleted(() => this.userManager.Value);
+
+        internal ProviderConfigManager ProviderConfigManager =>
+            this.IfNotDeleted(() => this.providerConfigManager.Value);
 
         /// <summary>
         /// Creates a Firebase custom token for the given user ID. This token can then be sent
@@ -1114,6 +1121,220 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
+        /// Looks up an OIDC auth provider configuration by the provided ID.
+        /// </summary>
+        /// <returns>A task that completes with a <see cref="OidcProviderConfig"/>.</returns>
+        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
+        /// contain the <c>oidc.</c> prefix.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist.</exception>
+        /// <param name="providerId">The ID of the OIDC provider config to return.</param>
+        public async Task<OidcProviderConfig> GetOidcProviderConfigAsync(string providerId)
+        {
+            return await this.GetOidcProviderConfigAsync(providerId, default(CancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Looks up an OIDC auth provider configuration by the provided ID.
+        /// </summary>
+        /// <returns>A task that completes with a <see cref="OidcProviderConfig"/>.</returns>
+        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
+        /// contain the <c>oidc.</c> prefix.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist.</exception>
+        /// <param name="providerId">The ID of the OIDC provider config to return.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        public async Task<OidcProviderConfig> GetOidcProviderConfigAsync(
+            string providerId, CancellationToken cancellationToken)
+        {
+            return await this.ProviderConfigManager
+                .GetOidcProviderConfigAsync(providerId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Looks up a SAML auth provider configuration by the provided ID.
+        /// </summary>
+        /// <returns>A task that completes with a <see cref="SamlProviderConfig"/>.</returns>
+        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
+        /// contain the <c>saml.</c> prefix.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist.</exception>
+        /// <param name="providerId">The ID of the SAML provider config to return.</param>
+        public async Task<SamlProviderConfig> GetSamlProviderConfigAsync(string providerId)
+        {
+            return await this.GetSamlProviderConfigAsync(providerId, default(CancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Looks up a SAML auth provider configuration by the provided ID.
+        /// </summary>
+        /// <returns>A task that completes with a <see cref="SamlProviderConfig"/>.</returns>
+        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
+        /// contain the <c>saml.</c> prefix.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist.</exception>
+        /// <param name="providerId">The ID of the SAML provider config to return.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        public async Task<SamlProviderConfig> GetSamlProviderConfigAsync(
+            string providerId, CancellationToken cancellationToken)
+        {
+            return await this.ProviderConfigManager
+                .GetSamlProviderConfigAsync(providerId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new auth provider configuration.
+        /// </summary>
+        /// <returns>A task that completes with an <see cref="AuthProviderConfig"/>.</returns>
+        /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
+        /// invalid.</exception>
+        /// <exception cref="FirebaseAuthException">If an unexpected error occurs while creating
+        /// the provider configuration.</exception>
+        /// <param name="args">Arguments that describe the new provider configuration.</param>
+        /// <typeparam name="T">Type of <see cref="AuthProviderConfig"/> to create.</typeparam>
+        public async Task<T> CreateProviderConfigAsync<T>(AuthProviderConfigArgs<T> args)
+        where T : AuthProviderConfig
+        {
+            return await this.CreateProviderConfigAsync(args, default(CancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Creates a new auth provider configuration.
+        /// </summary>
+        /// <returns>A task that completes with an <see cref="AuthProviderConfig"/>.</returns>
+        /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
+        /// invalid.</exception>
+        /// <exception cref="FirebaseAuthException">If an unexpected error occurs while creating
+        /// the provider configuration.</exception>
+        /// <param name="args">Arguments that describe the new provider configuration.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        /// <typeparam name="T">Type of <see cref="AuthProviderConfig"/> to create.</typeparam>
+        public async Task<T> CreateProviderConfigAsync<T>(
+            AuthProviderConfigArgs<T> args, CancellationToken cancellationToken)
+            where T : AuthProviderConfig
+        {
+            return await this.ProviderConfigManager
+                .CreateProviderConfigAsync(args, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Updates an existing auth provider configuration.
+        /// </summary>
+        /// <returns>A task that completes with the updated <see cref="AuthProviderConfig"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
+        /// invalid.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist or if an unexpected error occurs while performing the update.</exception>
+        /// <param name="args">Properties to be updated in the provider configuration.</param>
+        /// <typeparam name="T">Type of <see cref="AuthProviderConfig"/> to update.</typeparam>
+        public async Task<T> UpdateProviderConfigAsync<T>(AuthProviderConfigArgs<T> args)
+        where T : AuthProviderConfig
+        {
+            return await this.UpdateProviderConfigAsync(args, default(CancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Updates an existing auth provider configuration.
+        /// </summary>
+        /// <returns>A task that completes with the updated <see cref="AuthProviderConfig"/>.
+        /// </returns>
+        /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
+        /// invalid.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist or if an unexpected error occurs while performing the update.</exception>
+        /// <param name="args">Properties to be updated in the provider configuration.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        /// <typeparam name="T">Type of <see cref="AuthProviderConfig"/> to update.</typeparam>
+        public async Task<T> UpdateProviderConfigAsync<T>(
+            AuthProviderConfigArgs<T> args, CancellationToken cancellationToken)
+            where T : AuthProviderConfig
+        {
+            return await this.ProviderConfigManager
+                .UpdateProviderConfigAsync(args, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Deletes the specified auth provider configuration.
+        /// </summary>
+        /// <returns>A task that completes when the provider configuration is deleted.</returns>
+        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
+        /// contain either the <c>oidc.</c> or <c>saml.</c> prefix.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist.</exception>
+        /// <param name="providerId">ID of the provider configuration to delete.</param>
+        public async Task DeleteProviderConfigAsync(string providerId)
+        {
+            await this.DeleteProviderConfigAsync(providerId, default(CancellationToken))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Deletes the specified auth provider configuration.
+        /// </summary>
+        /// <returns>A task that completes when the provider configuration is deleted.</returns>
+        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
+        /// contain either the <c>oidc.</c> or <c>saml.</c> prefix.</exception>
+        /// <exception cref="FirebaseAuthException">If the specified provider config does not
+        /// exist.</exception>
+        /// <param name="providerId">ID of the provider configuration to delete.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        public async Task DeleteProviderConfigAsync(
+            string providerId, CancellationToken cancellationToken)
+        {
+            await this.ProviderConfigManager
+                .DeleteProviderConfigAsync(providerId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets an async enumerable to iterate or page through OIDC provider configurations
+        /// starting from the specified page token. If the page token is null or unspecified,
+        /// iteration starts from the first page. See
+        /// <a href="https://googleapis.github.io/google-cloud-dotnet/docs/guides/page-streaming.html">
+        /// Page Streaming</a> for more details on how to use this API.
+        /// </summary>
+        /// <param name="options">The options to control the starting point and page size. Pass
+        /// null to list from the beginning with default settings.</param>
+        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, OidcProviderConfig}"/>
+        /// instance.</returns>
+        public PagedAsyncEnumerable<AuthProviderConfigs<OidcProviderConfig>, OidcProviderConfig>
+            ListOidcProviderConfigsAsync(ListProviderConfigsOptions options)
+        {
+            return this.ProviderConfigManager.ListOidcProviderConfigsAsync(options);
+        }
+
+        /// <summary>
+        /// Gets an async enumerable to iterate or page through SAML provider configurations
+        /// starting from the specified page token. If the page token is null or unspecified,
+        /// iteration starts from the first page. See
+        /// <a href="https://googleapis.github.io/google-cloud-dotnet/docs/guides/page-streaming.html">
+        /// Page Streaming</a> for more details on how to use this API.
+        /// </summary>
+        /// <param name="options">The options to control the starting point and page size. Pass
+        /// null to list from the beginning with default settings.</param>
+        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, SamlProviderConfig}"/>
+        /// instance.</returns>
+        public PagedAsyncEnumerable<AuthProviderConfigs<SamlProviderConfig>, SamlProviderConfig>
+            ListSamlProviderConfigsAsync(ListProviderConfigsOptions options)
+        {
+            return this.ProviderConfigManager.ListSamlProviderConfigsAsync(options);
+        }
+
+        /// <summary>
         /// Deletes this <see cref="FirebaseAuth"/> service instance.
         /// </summary>
         void IFirebaseService.Delete()
@@ -1123,6 +1344,7 @@ namespace FirebaseAdmin.Auth
                 this.deleted = true;
                 this.tokenFactory.DisposeIfCreated();
                 this.userManager.DisposeIfCreated();
+                this.providerConfigManager.DisposeIfCreated();
                 this.Cleanup();
             }
         }
@@ -1160,6 +1382,8 @@ namespace FirebaseAdmin.Auth
             internal Lazy<FirebaseTokenVerifier> SessionCookieVerifier { get; set; }
 
             internal Lazy<FirebaseUserManager> UserManager { get; set; }
+
+            internal Lazy<ProviderConfigManager> ProviderConfigManager { get; set; }
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/FirebaseAuth.cs
@@ -13,12 +13,9 @@
 // limitations under the License.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using FirebaseAdmin.Auth.Jwt;
 using FirebaseAdmin.Auth.Multitenancy;
 using FirebaseAdmin.Auth.Providers;
-using Google.Api.Gax;
 using Google.Apis.Util;
 
 namespace FirebaseAdmin.Auth
@@ -29,14 +26,11 @@ namespace FirebaseAdmin.Auth
     /// </summary>
     public sealed class FirebaseAuth : AbstractFirebaseAuth
     {
-        private readonly Lazy<ProviderConfigManager> providerConfigManager;
         private readonly Lazy<TenantManager> tenantManager;
 
         internal FirebaseAuth(Args args)
         : base(args)
         {
-            this.providerConfigManager = args.ProviderConfigManager.ThrowIfNull(
-                nameof(args.ProviderConfigManager));
             this.tenantManager = args.TenantManager.ThrowIfNull(nameof(args.TenantManager));
         }
 
@@ -84,237 +78,10 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
-        /// Looks up an OIDC auth provider configuration by the provided ID.
-        /// </summary>
-        /// <returns>A task that completes with a <see cref="OidcProviderConfig"/>.</returns>
-        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
-        /// contain the <c>oidc.</c> prefix.</exception>
-        /// <exception cref="FirebaseAuthException">If the specified provider config does not
-        /// exist.</exception>
-        /// <param name="providerId">The ID of the OIDC provider config to return.</param>
-        public async Task<OidcProviderConfig> GetOidcProviderConfigAsync(string providerId)
-        {
-            return await this.GetOidcProviderConfigAsync(providerId, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Looks up an OIDC auth provider configuration by the provided ID.
-        /// </summary>
-        /// <returns>A task that completes with a <see cref="OidcProviderConfig"/>.</returns>
-        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
-        /// contain the <c>oidc.</c> prefix.</exception>
-        /// <exception cref="FirebaseAuthException">If the specified provider config does not
-        /// exist.</exception>
-        /// <param name="providerId">The ID of the OIDC provider config to return.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        public async Task<OidcProviderConfig> GetOidcProviderConfigAsync(
-            string providerId, CancellationToken cancellationToken)
-        {
-            var providerConfigManager = this.IfNotDeleted(
-                () => this.providerConfigManager.Value);
-            return await providerConfigManager
-                .GetOidcProviderConfigAsync(providerId, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Looks up a SAML auth provider configuration by the provided ID.
-        /// </summary>
-        /// <returns>A task that completes with a <see cref="SamlProviderConfig"/>.</returns>
-        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
-        /// contain the <c>saml.</c> prefix.</exception>
-        /// <exception cref="FirebaseAuthException">If the specified provider config does not
-        /// exist.</exception>
-        /// <param name="providerId">The ID of the SAML provider config to return.</param>
-        public async Task<SamlProviderConfig> GetSamlProviderConfigAsync(string providerId)
-        {
-            return await this.GetSamlProviderConfigAsync(providerId, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Looks up a SAML auth provider configuration by the provided ID.
-        /// </summary>
-        /// <returns>A task that completes with a <see cref="SamlProviderConfig"/>.</returns>
-        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
-        /// contain the <c>saml.</c> prefix.</exception>
-        /// <exception cref="FirebaseAuthException">If the specified provider config does not
-        /// exist.</exception>
-        /// <param name="providerId">The ID of the SAML provider config to return.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        public async Task<SamlProviderConfig> GetSamlProviderConfigAsync(
-            string providerId, CancellationToken cancellationToken)
-        {
-            var providerConfigManager = this.IfNotDeleted(
-                () => this.providerConfigManager.Value);
-            return await providerConfigManager
-                .GetSamlProviderConfigAsync(providerId, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Creates a new auth provider configuration.
-        /// </summary>
-        /// <returns>A task that completes with an <see cref="AuthProviderConfig"/>.</returns>
-        /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
-        /// invalid.</exception>
-        /// <exception cref="FirebaseAuthException">If an unexpected error occurs while creating
-        /// the provider configuration.</exception>
-        /// <param name="args">Arguments that describe the new provider configuration.</param>
-        /// <typeparam name="T">Type of <see cref="AuthProviderConfig"/> to create.</typeparam>
-        public async Task<T> CreateProviderConfigAsync<T>(AuthProviderConfigArgs<T> args)
-        where T : AuthProviderConfig
-        {
-            return await this.CreateProviderConfigAsync(args, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Creates a new auth provider configuration.
-        /// </summary>
-        /// <returns>A task that completes with an <see cref="AuthProviderConfig"/>.</returns>
-        /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
-        /// invalid.</exception>
-        /// <exception cref="FirebaseAuthException">If an unexpected error occurs while creating
-        /// the provider configuration.</exception>
-        /// <param name="args">Arguments that describe the new provider configuration.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        /// <typeparam name="T">Type of <see cref="AuthProviderConfig"/> to create.</typeparam>
-        public async Task<T> CreateProviderConfigAsync<T>(
-            AuthProviderConfigArgs<T> args, CancellationToken cancellationToken)
-            where T : AuthProviderConfig
-        {
-            var providerConfigManager = this.IfNotDeleted(
-                () => this.providerConfigManager.Value);
-            return await providerConfigManager.CreateProviderConfigAsync(args, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Updates an existing auth provider configuration.
-        /// </summary>
-        /// <returns>A task that completes with the updated <see cref="AuthProviderConfig"/>.
-        /// </returns>
-        /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
-        /// invalid.</exception>
-        /// <exception cref="FirebaseAuthException">If the specified provider config does not
-        /// exist or if an unexpected error occurs while performing the update.</exception>
-        /// <param name="args">Properties to be updated in the provider configuration.</param>
-        /// <typeparam name="T">Type of <see cref="AuthProviderConfig"/> to update.</typeparam>
-        public async Task<T> UpdateProviderConfigAsync<T>(AuthProviderConfigArgs<T> args)
-        where T : AuthProviderConfig
-        {
-            return await this.UpdateProviderConfigAsync(args, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Updates an existing auth provider configuration.
-        /// </summary>
-        /// <returns>A task that completes with the updated <see cref="AuthProviderConfig"/>.
-        /// </returns>
-        /// <exception cref="ArgumentException">If <paramref name="args"/> is null or
-        /// invalid.</exception>
-        /// <exception cref="FirebaseAuthException">If the specified provider config does not
-        /// exist or if an unexpected error occurs while performing the update.</exception>
-        /// <param name="args">Properties to be updated in the provider configuration.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        /// <typeparam name="T">Type of <see cref="AuthProviderConfig"/> to update.</typeparam>
-        public async Task<T> UpdateProviderConfigAsync<T>(
-            AuthProviderConfigArgs<T> args, CancellationToken cancellationToken)
-            where T : AuthProviderConfig
-        {
-            var providerConfigManager = this.IfNotDeleted(
-                () => this.providerConfigManager.Value);
-            return await providerConfigManager.UpdateProviderConfigAsync(args, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Deletes the specified auth provider configuration.
-        /// </summary>
-        /// <returns>A task that completes when the provider configuration is deleted.</returns>
-        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
-        /// contain either the <c>oidc.</c> or <c>saml.</c> prefix.</exception>
-        /// <exception cref="FirebaseAuthException">If the specified provider config does not
-        /// exist.</exception>
-        /// <param name="providerId">ID of the provider configuration to delete.</param>
-        public async Task DeleteProviderConfigAsync(string providerId)
-        {
-            await this.DeleteProviderConfigAsync(providerId, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Deletes the specified auth provider configuration.
-        /// </summary>
-        /// <returns>A task that completes when the provider configuration is deleted.</returns>
-        /// <exception cref="ArgumentException">If the provider ID is null, empty or does not
-        /// contain either the <c>oidc.</c> or <c>saml.</c> prefix.</exception>
-        /// <exception cref="FirebaseAuthException">If the specified provider config does not
-        /// exist.</exception>
-        /// <param name="providerId">ID of the provider configuration to delete.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        public async Task DeleteProviderConfigAsync(
-            string providerId, CancellationToken cancellationToken)
-        {
-            var providerConfigManager = this.IfNotDeleted(
-                () => this.providerConfigManager.Value);
-            await providerConfigManager
-                .DeleteProviderConfigAsync(providerId, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Gets an async enumerable to iterate or page through OIDC provider configurations
-        /// starting from the specified page token. If the page token is null or unspecified,
-        /// iteration starts from the first page. See
-        /// <a href="https://googleapis.github.io/google-cloud-dotnet/docs/guides/page-streaming.html">
-        /// Page Streaming</a> for more details on how to use this API.
-        /// </summary>
-        /// <param name="options">The options to control the starting point and page size. Pass
-        /// null to list from the beginning with default settings.</param>
-        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, OidcProviderConfig}"/>
-        /// instance.</returns>
-        public PagedAsyncEnumerable<AuthProviderConfigs<OidcProviderConfig>, OidcProviderConfig>
-            ListOidcProviderConfigsAsync(ListProviderConfigsOptions options)
-        {
-            var providerConfigManager = this.IfNotDeleted(
-                () => this.providerConfigManager.Value);
-            return providerConfigManager.ListOidcProviderConfigsAsync(options);
-        }
-
-        /// <summary>
-        /// Gets an async enumerable to iterate or page through SAML provider configurations
-        /// starting from the specified page token. If the page token is null or unspecified,
-        /// iteration starts from the first page. See
-        /// <a href="https://googleapis.github.io/google-cloud-dotnet/docs/guides/page-streaming.html">
-        /// Page Streaming</a> for more details on how to use this API.
-        /// </summary>
-        /// <param name="options">The options to control the starting point and page size. Pass
-        /// null to list from the beginning with default settings.</param>
-        /// <returns>A <see cref="PagedAsyncEnumerable{AuthProviderConfigs, SamlProviderConfig}"/>
-        /// instance.</returns>
-        public PagedAsyncEnumerable<AuthProviderConfigs<SamlProviderConfig>, SamlProviderConfig>
-            ListSamlProviderConfigsAsync(ListProviderConfigsOptions options)
-        {
-            var providerConfigManager = this.IfNotDeleted(
-                () => this.providerConfigManager.Value);
-            return providerConfigManager.ListSamlProviderConfigsAsync(options);
-        }
-
-        /// <summary>
         /// Deletes this <see cref="FirebaseAuth"/> service instance.
         /// </summary>
         internal override void Cleanup()
         {
-            this.providerConfigManager.DisposeIfCreated();
             this.tenantManager.DisposeIfCreated();
         }
 
@@ -340,8 +107,6 @@ namespace FirebaseAdmin.Auth
 
         internal sealed new class Args : AbstractFirebaseAuth.Args
         {
-            internal Lazy<ProviderConfigManager> ProviderConfigManager { get; set; }
-
             internal Lazy<TenantManager> TenantManager { get; set; }
 
             internal static Args CreateDefault()

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
@@ -16,6 +16,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using FirebaseAdmin.Auth.Jwt;
+using FirebaseAdmin.Auth.Providers;
 using Google.Apis.Util;
 
 namespace FirebaseAdmin.Auth.Multitenancy
@@ -65,6 +66,8 @@ namespace FirebaseAdmin.Auth.Multitenancy
                     () => FirebaseTokenVerifier.CreateSessionCookieVerifier(app, tenantId), true),
                 UserManager = new Lazy<FirebaseUserManager>(
                     () => FirebaseUserManager.Create(app, tenantId), true),
+                ProviderConfigManager = new Lazy<ProviderConfigManager>(
+                    () => Providers.ProviderConfigManager.Create(app, tenantId), true),
             };
             return new TenantAwareFirebaseAuth(args);
         }
@@ -81,6 +84,7 @@ namespace FirebaseAdmin.Auth.Multitenancy
                     IdTokenVerifier = new Lazy<FirebaseTokenVerifier>(),
                     SessionCookieVerifier = new Lazy<FirebaseTokenVerifier>(),
                     UserManager = new Lazy<FirebaseUserManager>(),
+                    ProviderConfigManager = new Lazy<ProviderConfigManager>(),
                     TenantId = tenantId,
                 };
             }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ApiClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ApiClient.cs
@@ -40,7 +40,9 @@ namespace FirebaseAdmin.Auth.Providers
         private readonly ErrorHandlingHttpClient<FirebaseAuthException> httpClient;
 
         internal ApiClient(
-            string projectId, ErrorHandlingHttpClientArgs<FirebaseAuthException> args)
+            string projectId,
+            string tenantId,
+            ErrorHandlingHttpClientArgs<FirebaseAuthException> args)
         {
             if (string.IsNullOrEmpty(projectId))
             {
@@ -49,7 +51,16 @@ namespace FirebaseAdmin.Auth.Providers
                     + " configurations.");
             }
 
-            this.baseUrl = string.Format(IdToolkitUrl, projectId);
+            var baseUrl = string.Format(IdToolkitUrl, projectId);
+            if (tenantId != null)
+            {
+                this.baseUrl = $"{baseUrl}/tenants/{tenantId}";
+            }
+            else
+            {
+                this.baseUrl = baseUrl;
+            }
+
             this.httpClient = new ErrorHandlingHttpClient<FirebaseAuthException>(args);
         }
 

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ProviderConfigManager.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ProviderConfigManager.cs
@@ -36,6 +36,12 @@ namespace FirebaseAdmin.Auth.Providers
         internal ProviderConfigManager(Args args)
         {
             args.ThrowIfNull(nameof(args));
+            this.TenantId = args.TenantId;
+            if (this.TenantId == string.Empty)
+            {
+                throw new ArgumentException("Tenant ID must not be empty.");
+            }
+
             var clientArgs = new ErrorHandlingHttpClientArgs<FirebaseAuthException>()
             {
                 HttpClientFactory = args.ClientFactory,
@@ -45,15 +51,17 @@ namespace FirebaseAdmin.Auth.Providers
                 DeserializeExceptionHandler = AuthErrorHandler.Instance,
                 RetryOptions = args.RetryOptions,
             };
-            this.apiClient = new ApiClient(args.ProjectId, clientArgs);
+            this.apiClient = new ApiClient(args.ProjectId, this.TenantId, clientArgs);
         }
+
+        internal string TenantId { get; }
 
         public void Dispose()
         {
             this.apiClient.Dispose();
         }
 
-        internal static ProviderConfigManager Create(FirebaseApp app)
+        internal static ProviderConfigManager Create(FirebaseApp app, string tenantId = null)
         {
             var args = new Args
             {
@@ -61,6 +69,7 @@ namespace FirebaseAdmin.Auth.Providers
                 Credential = app.Options.Credential,
                 ProjectId = app.GetProjectId(),
                 RetryOptions = RetryOptions.Default,
+                TenantId = tenantId,
             };
 
             return new ProviderConfigManager(args);
@@ -144,6 +153,8 @@ namespace FirebaseAdmin.Auth.Providers
             internal GoogleCredential Credential { get; set; }
 
             internal string ProjectId { get; set; }
+
+            internal string TenantId { get; set; }
 
             internal RetryOptions RetryOptions { get; set; }
         }

--- a/FirebaseAdmin/FirebaseAdmin/Util/HttpUtils.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/HttpUtils.cs
@@ -34,7 +34,8 @@ namespace FirebaseAdmin.Util
             var queryString = string.Empty;
             if (queryParams != null && queryParams.Count > 0)
             {
-                var list = queryParams.Select(kvp => $"{kvp.Key}={kvp.Value}");
+                var list = queryParams.OrderBy(kvp => kvp.Key)
+                    .Select(kvp => $"{kvp.Key}={kvp.Value}");
                 queryString = "?" + string.Join("&", list);
             }
 


### PR DESCRIPTION
* Moved all provider config management APIs to `AbstractFirebaseAuth`.
* Implemented support for tenant-aware provider config management in `ProviderConfigManager` and `ApiClient`.
* Turned `ProviderConfigTestUtils` into `ProviderTestConfig`, so it can be used as the means to parametrize unit tests.