### PR TITLE
fix(auth): Removing tenant-aware session cookie APIs

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
@@ -77,8 +77,16 @@ namespace FirebaseAdmin.Auth.Tests
 
             if (options.SessionCookieVerifier)
             {
-                args.SessionCookieVerifier = new Lazy<FirebaseTokenVerifier>(
-                    this.CreateSessionCookieVerifier());
+                if (args is FirebaseAuth.Args)
+                {
+                    (args as FirebaseAuth.Args).SessionCookieVerifier =
+                        new Lazy<FirebaseTokenVerifier>(this.CreateSessionCookieVerifier());
+                }
+                else
+                {
+                    throw new InvalidOperationException(
+                        $"Session cookie verification not supported on {args.GetType()}");
+                }
             }
         }
 
@@ -116,7 +124,7 @@ namespace FirebaseAdmin.Auth.Tests
         private FirebaseTokenVerifier CreateSessionCookieVerifier()
         {
             return FirebaseTokenVerifier.CreateSessionCookieVerifier(
-                this.ProjectId, this.KeySource, this.Clock, this.TenantId);
+                this.ProjectId, this.KeySource, this.Clock);
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
@@ -48,7 +48,6 @@ namespace FirebaseAdmin.Auth.Multitenancy
 
             Assert.Throws<InvalidOperationException>(() => auth.TokenFactory);
             Assert.Throws<InvalidOperationException>(() => auth.IdTokenVerifier);
-            Assert.Throws<InvalidOperationException>(() => auth.SessionCookieVerifier);
             Assert.Throws<InvalidOperationException>(() => auth.UserManager);
             Assert.Throws<InvalidOperationException>(() => auth.ProviderConfigManager);
         }
@@ -63,7 +62,6 @@ namespace FirebaseAdmin.Auth.Multitenancy
             Assert.Equal(MockTenantId, auth.TenantId);
             Assert.Equal(MockTenantId, auth.TokenFactory.TenantId);
             Assert.Equal(MockTenantId, auth.IdTokenVerifier.TenantId);
-            Assert.Equal(MockTenantId, auth.SessionCookieVerifier.TenantId);
             Assert.Equal(MockTenantId, auth.UserManager.TenantId);
             Assert.Equal(MockTenantId, auth.ProviderConfigManager.TenantId);
         }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/UserRecordTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/UserRecordTest.cs
@@ -85,6 +85,7 @@ namespace FirebaseAdmin.Auth.Tests
                 CreatedAt = 100,
                 LastLoginAt = 150,
                 CustomClaims = @"{""admin"": true, ""level"": 10}",
+                TenantId = "tenant1",
                 Providers = new List<GetAccountInfoResponse.Provider>()
                 {
                     new GetAccountInfoResponse.Provider()
@@ -121,6 +122,7 @@ namespace FirebaseAdmin.Auth.Tests
                 { "level", 10L },
             };
             Assert.Equal(claims, user.CustomClaims);
+            Assert.Equal("tenant1", user.TenantId);
 
             Assert.Equal(2, user.ProviderData.Length);
             var provider = user.ProviderData[0];

--- a/FirebaseAdmin/FirebaseAdmin/Auth/AbstractFirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/AbstractFirebaseAuth.cs
@@ -33,7 +33,6 @@ namespace FirebaseAdmin.Auth
         private readonly object authLock = new object();
         private readonly Lazy<FirebaseTokenFactory> tokenFactory;
         private readonly Lazy<FirebaseTokenVerifier> idTokenVerifier;
-        private readonly Lazy<FirebaseTokenVerifier> sessionCookieVerifier;
         private readonly Lazy<FirebaseUserManager> userManager;
         private readonly Lazy<ProviderConfigManager> providerConfigManager;
         private bool deleted;
@@ -43,8 +42,6 @@ namespace FirebaseAdmin.Auth
             args.ThrowIfNull(nameof(args));
             this.tokenFactory = args.TokenFactory.ThrowIfNull(nameof(args.TokenFactory));
             this.idTokenVerifier = args.IdTokenVerifier.ThrowIfNull(nameof(args.IdTokenVerifier));
-            this.sessionCookieVerifier = args.SessionCookieVerifier.ThrowIfNull(
-                nameof(args.SessionCookieVerifier));
             this.userManager = args.UserManager.ThrowIfNull(nameof(args.UserManager));
             this.providerConfigManager = args.ProviderConfigManager.ThrowIfNull(
                 nameof(args.ProviderConfigManager));
@@ -55,9 +52,6 @@ namespace FirebaseAdmin.Auth
 
         internal FirebaseTokenVerifier IdTokenVerifier =>
             this.IfNotDeleted(() => this.idTokenVerifier.Value);
-
-        internal FirebaseTokenVerifier SessionCookieVerifier =>
-            this.IfNotDeleted(() => this.sessionCookieVerifier.Value);
 
         internal FirebaseUserManager UserManager =>
             this.IfNotDeleted(() => this.userManager.Value);
@@ -987,141 +981,6 @@ namespace FirebaseAdmin.Auth
         }
 
         /// <summary>
-        /// Creates a new Firebase session cookie from the given ID token and options. The returned JWT can
-        /// be set as a server-side session cookie with a custom cookie policy.
-        /// </summary>
-        /// <exception cref="FirebaseAuthException">If an error occurs while creating the cookie.</exception>
-        /// <param name="idToken">The Firebase ID token to exchange for a session cookie.</param>
-        /// <param name="options">Additional options required to create the cookie.</param>
-        /// <returns>A task that completes with the Firebase session cookie.</returns>
-        public async Task<string> CreateSessionCookieAsync(
-            string idToken, SessionCookieOptions options)
-        {
-            return await this.CreateSessionCookieAsync(idToken, options, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Creates a new Firebase session cookie from the given ID token and options. The returned JWT can
-        /// be set as a server-side session cookie with a custom cookie policy.
-        /// </summary>
-        /// <exception cref="FirebaseAuthException">If an error occurs while creating the cookie.</exception>
-        /// <param name="idToken">The Firebase ID token to exchange for a session cookie.</param>
-        /// <param name="options">Additional options required to create the cookie.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        /// <returns>A task that completes with the Firebase session cookie.</returns>
-        public virtual async Task<string> CreateSessionCookieAsync(
-            string idToken, SessionCookieOptions options, CancellationToken cancellationToken)
-        {
-            return await this.UserManager
-                .CreateSessionCookieAsync(idToken, options, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Parses and verifies a Firebase session cookie.
-        ///
-        /// <para>See <a href="https://firebase.google.com/docs/auth/admin/manage-cookies">Manage
-        /// Session Cookies</a> for code samples and detailed documentation.</para>
-        /// </summary>
-        /// <returns>A task that completes with a <see cref="FirebaseToken"/> representing
-        /// the verified and decoded session cookie.</returns>
-        /// <exception cref="ArgumentException">If the session cookie is null or
-        /// empty.</exception>
-        /// <exception cref="FirebaseAuthException">If the session cookie is invalid.</exception>
-        /// <param name="sessionCookie">A Firebase session cookie string to verify and
-        /// parse.</param>
-        public async Task<FirebaseToken> VerifySessionCookieAsync(string sessionCookie)
-        {
-            return await this.VerifySessionCookieAsync(sessionCookie, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Parses and verifies a Firebase session cookie.
-        ///
-        /// <para>See <a href="https://firebase.google.com/docs/auth/admin/manage-cookies">Manage
-        /// Session Cookies</a> for code samples and detailed documentation.</para>
-        /// </summary>
-        /// <returns>A task that completes with a <see cref="FirebaseToken"/> representing
-        /// the verified and decoded session cookie.</returns>
-        /// <exception cref="ArgumentException">If the session cookie is null or
-        /// empty.</exception>
-        /// <exception cref="FirebaseAuthException">If the session cookie is invalid.</exception>
-        /// <param name="sessionCookie">A Firebase session cookie string to verify and
-        /// parse.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        public async Task<FirebaseToken> VerifySessionCookieAsync(
-            string sessionCookie, CancellationToken cancellationToken)
-        {
-            return await this.VerifySessionCookieAsync(sessionCookie, false, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Parses and verifies a Firebase session cookie.
-        ///
-        /// <para>See <a href="https://firebase.google.com/docs/auth/admin/manage-cookies">Manage
-        /// Session Cookies</a> for code samples and detailed documentation.</para>
-        /// </summary>
-        /// <returns>A task that completes with a <see cref="FirebaseToken"/> representing
-        /// the verified and decoded session cookie.</returns>
-        /// <exception cref="ArgumentException">If the session cookie is null or
-        /// empty.</exception>
-        /// <exception cref="FirebaseAuthException">If the session cookie is invalid.</exception>
-        /// <param name="sessionCookie">A Firebase session cookie string to verify and
-        /// parse.</param>
-        /// <param name="checkRevoked">A boolean indicating whether to check if the tokens were
-        /// revoked.</param>
-        public async Task<FirebaseToken> VerifySessionCookieAsync(
-            string sessionCookie, bool checkRevoked)
-        {
-            return await this
-                .VerifySessionCookieAsync(sessionCookie, checkRevoked, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Parses and verifies a Firebase session cookie.
-        ///
-        /// <para>See <a href="https://firebase.google.com/docs/auth/admin/manage-cookies">Manage
-        /// Session Cookies</a> for code samples and detailed documentation.</para>
-        /// </summary>
-        /// <returns>A task that completes with a <see cref="FirebaseToken"/> representing
-        /// the verified and decoded session cookie.</returns>
-        /// <exception cref="ArgumentException">If the session cookie is null or
-        /// empty.</exception>
-        /// <exception cref="FirebaseAuthException">If the session cookie is invalid.</exception>
-        /// <param name="sessionCookie">A Firebase session cookie string to verify and
-        /// parse.</param>
-        /// <param name="checkRevoked">A boolean indicating whether to check if the tokens were
-        /// revoked.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        public async Task<FirebaseToken> VerifySessionCookieAsync(
-            string sessionCookie, bool checkRevoked, CancellationToken cancellationToken)
-        {
-            var decodedToken = await this.SessionCookieVerifier
-                .VerifyTokenAsync(sessionCookie, cancellationToken)
-                .ConfigureAwait(false);
-            if (checkRevoked)
-            {
-                var revoked = await this.IsRevokedAsync(decodedToken, cancellationToken);
-                if (revoked)
-                {
-                    throw new FirebaseAuthException(
-                        ErrorCode.InvalidArgument,
-                        "Firebase session cookie has been revoked.",
-                        AuthErrorCode.RevokedSessionCookie);
-                }
-            }
-
-            return decodedToken;
-        }
-
-        /// <summary>
         /// Looks up an OIDC auth provider configuration by the provided ID.
         /// </summary>
         /// <returns>A task that completes with a <see cref="OidcProviderConfig"/>.</returns>
@@ -1365,7 +1224,7 @@ namespace FirebaseAdmin.Auth
             }
         }
 
-        private async Task<bool> IsRevokedAsync(
+        private protected async Task<bool> IsRevokedAsync(
             FirebaseToken token, CancellationToken cancellationToken)
         {
             var user = await this.GetUserAsync(token.Uid, cancellationToken);
@@ -1379,8 +1238,6 @@ namespace FirebaseAdmin.Auth
             internal Lazy<FirebaseTokenFactory> TokenFactory { get; set; }
 
             internal Lazy<FirebaseTokenVerifier> IdTokenVerifier { get; set; }
-
-            internal Lazy<FirebaseTokenVerifier> SessionCookieVerifier { get; set; }
 
             internal Lazy<FirebaseUserManager> UserManager { get; set; }
 

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
@@ -126,8 +126,7 @@ namespace FirebaseAdmin.Auth.Jwt
             return new FirebaseTokenVerifier(args);
         }
 
-        internal static FirebaseTokenVerifier CreateSessionCookieVerifier(
-            FirebaseApp app, string tenantId = null)
+        internal static FirebaseTokenVerifier CreateSessionCookieVerifier(FirebaseApp app)
         {
             var projectId = app.GetProjectId();
             if (string.IsNullOrEmpty(projectId))
@@ -138,19 +137,17 @@ namespace FirebaseAdmin.Auth.Jwt
 
             var keySource = new HttpPublicKeySource(
                 SessionCookieCertUrl, SystemClock.Default, app.Options.HttpClientFactory);
-            return CreateSessionCookieVerifier(projectId, keySource, tenantId: tenantId);
+            return CreateSessionCookieVerifier(projectId, keySource);
         }
 
         internal static FirebaseTokenVerifier CreateSessionCookieVerifier(
             string projectId,
             IPublicKeySource keySource,
-            IClock clock = null,
-            string tenantId = null)
+            IClock clock = null)
         {
             var args = new FirebaseTokenVerifierArgs()
             {
                 ProjectId = projectId,
-                TenantId = tenantId,
                 ShortName = "session cookie",
                 Operation = "VerifySessionCookieAsync()",
                 Url = "https://firebase.google.com/docs/auth/admin/manage-cookies",

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Multitenancy/TenantAwareFirebaseAuth.cs
@@ -13,12 +13,9 @@
 // limitations under the License.
 
 using System;
-using System.Threading;
-using System.Threading.Tasks;
 using FirebaseAdmin.Auth.Jwt;
 using FirebaseAdmin.Auth.Providers;
 using FirebaseAdmin.Auth.Users;
-using Google.Apis.Util;
 
 namespace FirebaseAdmin.Auth.Multitenancy
 {
@@ -43,17 +40,6 @@ namespace FirebaseAdmin.Auth.Multitenancy
         /// </summary>
         public string TenantId { get; }
 
-        /// <inheritdoc/>
-        public override async Task<string> CreateSessionCookieAsync(
-            string idToken, SessionCookieOptions options, CancellationToken cancellationToken)
-        {
-            // As a minor optimization, validate options here before calling VerifyIdToken().
-            options.ThrowIfNull(nameof(options)).CopyAndValidate();
-            await this.VerifyIdTokenAsync(idToken, cancellationToken);
-            return await base.CreateSessionCookieAsync(idToken, options, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
         internal static TenantAwareFirebaseAuth Create(FirebaseApp app, string tenantId)
         {
             var args = new Args
@@ -63,8 +49,6 @@ namespace FirebaseAdmin.Auth.Multitenancy
                     () => FirebaseTokenFactory.Create(app, tenantId), true),
                 IdTokenVerifier = new Lazy<FirebaseTokenVerifier>(
                     () => FirebaseTokenVerifier.CreateIdTokenVerifier(app, tenantId), true),
-                SessionCookieVerifier = new Lazy<FirebaseTokenVerifier>(
-                    () => FirebaseTokenVerifier.CreateSessionCookieVerifier(app, tenantId), true),
                 UserManager = new Lazy<FirebaseUserManager>(
                     () => FirebaseUserManager.Create(app, tenantId), true),
                 ProviderConfigManager = new Lazy<ProviderConfigManager>(
@@ -83,7 +67,6 @@ namespace FirebaseAdmin.Auth.Multitenancy
                 {
                     TokenFactory = new Lazy<FirebaseTokenFactory>(),
                     IdTokenVerifier = new Lazy<FirebaseTokenVerifier>(),
-                    SessionCookieVerifier = new Lazy<FirebaseTokenVerifier>(),
                     UserManager = new Lazy<FirebaseUserManager>(),
                     ProviderConfigManager = new Lazy<ProviderConfigManager>(),
                     TenantId = tenantId,

--- a/FirebaseAdmin/FirebaseAdmin/Auth/SessionCookieOptions.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/SessionCookieOptions.cs
@@ -18,7 +18,7 @@ namespace FirebaseAdmin.Auth
 {
     /// <summary>
     /// Options for the
-    /// <see cref="AbstractFirebaseAuth.CreateSessionCookieAsync(string, SessionCookieOptions)"/>
+    /// <see cref="FirebaseAuth.CreateSessionCookieAsync(string, SessionCookieOptions)"/>
     /// API.
     /// </summary>
     public sealed class SessionCookieOptions

--- a/FirebaseAdmin/FirebaseAdmin/Auth/UserRecord.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/UserRecord.cs
@@ -85,6 +85,7 @@ namespace FirebaseAdmin.Auth
 
             this.UserMetaData = new UserMetadata(user.CreatedAt, user.LastLoginAt, lastRefreshAt);
             this.CustomClaims = UserRecord.ParseCustomClaims(user.CustomClaims);
+            this.TenantId = user.TenantId;
         }
 
         /// <summary>
@@ -154,6 +155,11 @@ namespace FirebaseAdmin.Auth
         /// Gets the custom claims set on this user, as a non-null dictionary. Possibly empty.
         /// </summary>
         public IReadOnlyDictionary<string, object> CustomClaims { get; }
+
+        /// <summary>
+        /// Gets the user's tenant ID, if available. Otherwise null.
+        /// </summary>
+        public string TenantId { get; }
 
         private static IReadOnlyDictionary<string, object> ParseCustomClaims(string customClaims)
         {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Users/GetAccountInfoResponse.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Users/GetAccountInfoResponse.cs
@@ -129,6 +129,12 @@ namespace FirebaseAdmin.Auth.Users
             /// </summary>
             [JsonProperty(PropertyName = "customAttributes")]
             public string CustomClaims { get; set; }
+
+            /// <summary>
+            /// Gets or sets the user's tenant ID.
+            /// </summary>
+            [JsonProperty(PropertyName = "tenantId")]
+            public string TenantId { get; set; }
         }
 
         /// <summary>


### PR DESCRIPTION
* It turns out the Auth backend infrastructure doesn't support tenant-scoped session cookies yet. Therefore I'm moving the corresponding APIs from `AbstractFirebaseAuth` back to `FirebaseAuth`.
* Removed `CreateSessionCookieAsync()` method in `TenantAwareFirebaseAuth`.
* I'm keeping most of the test utils we've implemented unchanged, since they will come in handy in the future when we do implement tenant-scoped cookie support.

* Exposing `UserRecord.TenantId` getter. 