### PR TITLE
fix(auth): Reusing ListResourcesRequest util in all pagination APIs

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ApiClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/ApiClient.cs
@@ -35,8 +35,6 @@ namespace FirebaseAdmin.Auth.Providers
 
         private static readonly string ClientVersion = $"DotNet/Admin/{FirebaseApp.GetSdkVersion()}";
 
-        private readonly string baseUrl;
-
         private readonly ErrorHandlingHttpClient<FirebaseAuthException> httpClient;
 
         internal ApiClient(
@@ -54,15 +52,17 @@ namespace FirebaseAdmin.Auth.Providers
             var baseUrl = string.Format(IdToolkitUrl, projectId);
             if (tenantId != null)
             {
-                this.baseUrl = $"{baseUrl}/tenants/{tenantId}";
+                this.BaseUrl = $"{baseUrl}/tenants/{tenantId}";
             }
             else
             {
-                this.baseUrl = baseUrl;
+                this.BaseUrl = baseUrl;
             }
 
             this.httpClient = new ErrorHandlingHttpClient<FirebaseAuthException>(args);
         }
+
+        internal string BaseUrl { get; }
 
         public void Dispose()
         {
@@ -74,7 +74,7 @@ namespace FirebaseAdmin.Auth.Providers
         {
             if (!request.RequestUri.IsAbsoluteUri)
             {
-                request.RequestUri = new Uri($"{this.baseUrl}/{request.RequestUri}");
+                request.RequestUri = new Uri($"{this.BaseUrl}/{request.RequestUri}");
             }
 
             if (!request.Headers.Contains(ClientVersionHeader))

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigClient.cs
@@ -69,8 +69,6 @@ namespace FirebaseAdmin.Auth.Providers
             internal ListRequest(ApiClient client, ListProviderConfigsOptions options)
             : base(client, options) { }
 
-            public override string MethodName => "ListOidcProviderConfigs";
-
             public override string RestPath => "oauthIdpConfigs";
 
             public override async Task<AuthProviderConfigs<OidcProviderConfig>> ExecuteAsync(

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/SamlProviderConfigClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/SamlProviderConfigClient.cs
@@ -69,8 +69,6 @@ namespace FirebaseAdmin.Auth.Providers
             internal ListRequest(ApiClient client, ListProviderConfigsOptions options)
             : base(client, options) { }
 
-            public override string MethodName => "ListSamlProviderConfigs";
-
             public override string RestPath => "inboundSamlConfigs";
 
             public override async Task<AuthProviderConfigs<SamlProviderConfig>> ExecuteAsync(

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Users/FirebaseUserManager.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Users/FirebaseUserManager.cs
@@ -215,11 +215,12 @@ namespace FirebaseAdmin.Auth.Users
         internal Gax.PagedAsyncEnumerable<ExportedUserRecords, ExportedUserRecord> ListUsers(
             ListUsersOptions options)
         {
-            var factory = new ListUsersRequest.Factory(this.baseUrl, this.httpClient, options);
+            Func<ListUsersRequest> validateAndCreate = () => new ListUsersRequest(
+                this.baseUrl, this.httpClient, options);
+            validateAndCreate();
             return new RestPagedAsyncEnumerable
                 <ListUsersRequest, ExportedUserRecords, ExportedUserRecord>(
-                () => factory.Create(),
-                new ListUsersPageManager());
+                validateAndCreate, new ListUsersPageManager());
         }
 
         /// <summary>

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Users/FirebaseUserManager.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Users/FirebaseUserManager.cs
@@ -216,7 +216,7 @@ namespace FirebaseAdmin.Auth.Users
             ListUsersOptions options)
         {
             Func<ListUsersRequest> validateAndCreate = () => new ListUsersRequest(
-                this.baseUrl, this.httpClient, options);
+                this.baseUrl, options, this.httpClient);
             validateAndCreate();
             return new RestPagedAsyncEnumerable
                 <ListUsersRequest, ExportedUserRecords, ExportedUserRecord>(

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Users/ListUsersRequest.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Users/ListUsersRequest.cs
@@ -12,17 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FirebaseAdmin.Util;
-using Google.Apis.Discovery;
-using Google.Apis.Requests;
-using Google.Apis.Services;
 
 namespace FirebaseAdmin.Auth.Users
 {
@@ -30,187 +24,45 @@ namespace FirebaseAdmin.Auth.Users
     /// Represents a request made using the Google API client to list all Firebase users in a
     /// project.
     /// </summary>
-    internal sealed class ListUsersRequest : IClientServiceRequest<ExportedUserRecords>
+    internal sealed class ListUsersRequest
+    : ListResourcesRequest<ExportedUserRecords, FirebaseAuthException>
     {
-        private const int MaxListUsersResults = 1000;
-
-        private readonly string baseUrl;
-        private readonly ErrorHandlingHttpClient<FirebaseAuthException> httpClient;
-
-        private ListUsersRequest(
+        internal ListUsersRequest(
             string baseUrl,
             ErrorHandlingHttpClient<FirebaseAuthException> httpClient,
             ListUsersOptions options)
+        : base(baseUrl, httpClient, options?.PageToken, options?.PageSize) { }
+
+        public override string RestPath => "accounts:batchGet";
+
+        protected override string PageSizeParam => "maxResults";
+
+        protected override string PageTokenParam => "nextPageToken";
+
+        protected override int MaxResults => 1000;
+
+        public override HttpRequestMessage CreateRequest(bool? overrideGZipEnabled = null)
         {
-            this.baseUrl = baseUrl;
-            this.httpClient = httpClient;
-            this.RequestParameters = new Dictionary<string, IParameter>();
-            this.SetPageSize(options.PageSize);
-            this.SetPageToken(options.PageToken);
-        }
-
-        public string MethodName => "ListUsers";
-
-        public string RestPath => "accounts:batchGet";
-
-        public string HttpMethod => "GET";
-
-        public IDictionary<string, IParameter> RequestParameters { get; }
-
-        public IClientService Service { get; }
-
-        public HttpRequestMessage CreateRequest(bool? overrideGZipEnabled = null)
-        {
-            var orderedParams = this.RequestParameters
-                .OrderBy(kpv => kpv.Key)
-                .Select(kvp => $"{kvp.Key}={kvp.Value.DefaultValue}");
-            var queryParameters = string.Join("&", orderedParams);
-            var request = new HttpRequestMessage()
-            {
-                Method = System.Net.Http.HttpMethod.Get,
-                RequestUri = new Uri($"{this.baseUrl}/{this.RestPath}?{queryParameters}"),
-            };
-            request.Headers.Add(FirebaseUserManager.ClientVersionHeader, FirebaseUserManager.ClientVersion);
+            var request = base.CreateRequest(overrideGZipEnabled);
+            request.Headers.Add(
+                FirebaseUserManager.ClientVersionHeader, FirebaseUserManager.ClientVersion);
             return request;
         }
 
-        public async Task<Stream> ExecuteAsStreamAsync()
+        public override async Task<ExportedUserRecords> ExecuteAsync(
+            CancellationToken cancellationToken)
         {
-            return await this.ExecuteAsStreamAsync(default).ConfigureAwait(false);
-        }
-
-        public async Task<Stream> ExecuteAsStreamAsync(CancellationToken cancellationToken)
-        {
-            var response = await this.httpClient.SendAsync(this.CreateRequest(), cancellationToken)
+            var request = this.CreateRequest();
+            var downloadAccountResponse = await this.HttpClient
+                .SendAndDeserializeAsync<DownloadAccountResponse>(request, cancellationToken)
                 .ConfigureAwait(false);
-            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-        }
-
-        public Stream ExecuteAsStream()
-        {
-            return this.ExecuteAsStreamAsync().Result;
-        }
-
-        public async Task<ExportedUserRecords> ExecuteAsync()
-        {
-            return await this.ExecuteAsync(default).ConfigureAwait(false);
-        }
-
-        public async Task<ExportedUserRecords> ExecuteAsync(CancellationToken cancellationToken)
-        {
-            var downloadAccountResponse = await this.SendAndDeserializeAsync(
-                this.CreateRequest(), cancellationToken).ConfigureAwait(false);
-            var userRecords = downloadAccountResponse.Users?.Select(
+            var userRecords = downloadAccountResponse.Result.Users?.Select(
                 u => new ExportedUserRecord(u));
             return new ExportedUserRecords
             {
-                NextPageToken = downloadAccountResponse.NextPageToken,
+                NextPageToken = downloadAccountResponse.Result.NextPageToken,
                 Users = userRecords,
             };
-        }
-
-        public ExportedUserRecords Execute()
-        {
-            return this.ExecuteAsync().Result;
-        }
-
-        internal void SetPageSize(int? pageSize)
-        {
-            this.AddOrUpdate("maxResults", CheckPageSize(pageSize).ToString());
-        }
-
-        internal void SetPageToken(string pageToken)
-        {
-            if (pageToken != null)
-            {
-                this.AddOrUpdate("nextPageToken", CheckPageToken(pageToken));
-            }
-            else
-            {
-                this.RequestParameters.Remove("nextPageToken");
-            }
-        }
-
-        private static int CheckPageSize(int? pageSize)
-        {
-            if (pageSize > MaxListUsersResults)
-            {
-                throw new ArgumentException("Page size must not exceed 1000.");
-            }
-            else if (pageSize <= 0)
-            {
-                throw new ArgumentException("Page size must be positive.");
-            }
-
-            return pageSize ?? MaxListUsersResults;
-        }
-
-        private static string CheckPageToken(string token)
-        {
-            if (token == string.Empty)
-            {
-                throw new ArgumentException("Page token must not be empty.");
-            }
-
-            return token;
-        }
-
-        private void AddOrUpdate(string paramName, string value)
-        {
-            var parameter = new Parameter()
-            {
-                DefaultValue = value,
-                IsRequired = true,
-                Name = paramName,
-            };
-
-            if (!this.RequestParameters.ContainsKey(paramName))
-            {
-                this.RequestParameters.Add(paramName, parameter);
-            }
-            else
-            {
-                this.RequestParameters[paramName] = parameter;
-            }
-        }
-
-        private async Task<DownloadAccountResponse> SendAndDeserializeAsync(
-            HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            var response = await this.httpClient
-                .SendAndDeserializeAsync<DownloadAccountResponse>(request, cancellationToken)
-                .ConfigureAwait(false);
-            return response.Result;
-        }
-
-        /// <summary>
-        /// Factory class that validates arguments, and then creates new instances of the
-        /// <see cref="ListUsersRequest"/> class.
-        /// </summary>
-        internal sealed class Factory
-        {
-            private readonly string baseUrl;
-            private readonly ErrorHandlingHttpClient<FirebaseAuthException> httpClient;
-            private readonly ListUsersOptions options;
-
-            internal Factory(
-                string baseUrl,
-                ErrorHandlingHttpClient<FirebaseAuthException> httpClient,
-                ListUsersOptions options = null)
-            {
-                this.baseUrl = baseUrl;
-                this.httpClient = httpClient;
-                this.options = new ListUsersOptions()
-                {
-                    PageSize = CheckPageSize(options?.PageSize),
-                    PageToken = CheckPageToken(options?.PageToken),
-                };
-            }
-
-            internal ListUsersRequest Create()
-            {
-                return new ListUsersRequest(this.baseUrl, this.httpClient, this.options);
-            }
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Users/ListUsersRequest.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Users/ListUsersRequest.cs
@@ -25,13 +25,13 @@ namespace FirebaseAdmin.Auth.Users
     /// project.
     /// </summary>
     internal sealed class ListUsersRequest
-    : ListResourcesRequest<ExportedUserRecords, FirebaseAuthException>
+    : AdaptedListResourcesRequest<ExportedUserRecords, FirebaseAuthException>
     {
         internal ListUsersRequest(
             string baseUrl,
-            ErrorHandlingHttpClient<FirebaseAuthException> httpClient,
-            ListUsersOptions options)
-        : base(baseUrl, httpClient, options?.PageToken, options?.PageSize) { }
+            ListUsersOptions options,
+            ErrorHandlingHttpClient<FirebaseAuthException> httpClient)
+        : base(baseUrl, options?.PageToken, options?.PageSize, httpClient) { }
 
         public override string RestPath => "accounts:batchGet";
 
@@ -52,15 +52,14 @@ namespace FirebaseAdmin.Auth.Users
         public override async Task<ExportedUserRecords> ExecuteAsync(
             CancellationToken cancellationToken)
         {
-            var request = this.CreateRequest();
-            var downloadAccountResponse = await this.HttpClient
-                .SendAndDeserializeAsync<DownloadAccountResponse>(request, cancellationToken)
+            var downloadAccountResponse = await this
+                .SendAndDeserializeAsync<DownloadAccountResponse>(cancellationToken)
                 .ConfigureAwait(false);
-            var userRecords = downloadAccountResponse.Result.Users?.Select(
+            var userRecords = downloadAccountResponse.Users?.Select(
                 u => new ExportedUserRecord(u));
             return new ExportedUserRecords
             {
-                NextPageToken = downloadAccountResponse.Result.NextPageToken,
+                NextPageToken = downloadAccountResponse.NextPageToken,
                 Users = userRecords,
             };
         }

--- a/FirebaseAdmin/FirebaseAdmin/Util/AdaptedListResourcesRequest.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/AdaptedListResourcesRequest.cs
@@ -1,0 +1,59 @@
+// Copyright 2020, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FirebaseAdmin.Util
+{
+    /// <summary>
+    /// An implementation of <see cref="ListResourcesRequest{TResult}"/> that uses the
+    /// <see cref="ErrorHandlingHttpClient{T}"/> API to communicate with the backend server.
+    /// </summary>
+    internal abstract class AdaptedListResourcesRequest<TResult, TException>
+    : ListResourcesRequest<TResult>
+    where TException : FirebaseException
+    {
+        private readonly ErrorHandlingHttpClient<TException> httpClient;
+
+        public AdaptedListResourcesRequest(
+            string baseUrl,
+            string pageToken,
+            int? pageSize,
+            ErrorHandlingHttpClient<TException> httpClient)
+        : base(baseUrl, pageToken, pageSize)
+        {
+            this.httpClient = httpClient;
+        }
+
+        public override async Task<Stream> ExecuteAsStreamAsync(CancellationToken cancellationToken)
+        {
+            var request = this.CreateRequest();
+            var response = await this.httpClient.SendAsync(request, cancellationToken)
+                .ConfigureAwait(false);
+            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        }
+
+        private protected async Task<T> SendAndDeserializeAsync<T>(
+            CancellationToken cancellationToken)
+        {
+            var request = this.CreateRequest();
+            var response = await this.httpClient
+                .SendAndDeserializeAsync<T>(request, cancellationToken)
+                .ConfigureAwait(false);
+            return response.Result;
+        }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Util/ListResourcesRequest.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Util/ListResourcesRequest.cs
@@ -25,20 +25,19 @@ using Google.Apis.Services;
 
 namespace FirebaseAdmin.Util
 {
-    internal abstract class ListResourcesRequest<TResult, TException>
-    : IClientServiceRequest<TResult>
-    where TException : FirebaseException
+    /// <summary>
+    /// A Google client service request implementation that supports paginating through a list of
+    /// resources. This parent class implements most of the argument validation and HTTP request
+    /// marshaling logic, but leaves the actual transport behavior to be implemented by the child
+    /// classes.
+    /// </summary>
+    internal abstract class ListResourcesRequest<TResult> : IClientServiceRequest<TResult>
     {
         private readonly string baseUrl;
 
-        public ListResourcesRequest(
-            string baseUrl,
-            ErrorHandlingHttpClient<TException> httpClient,
-            string pageToken,
-            int? pageSize)
+        public ListResourcesRequest(string baseUrl, string pageToken, int? pageSize)
         {
             this.baseUrl = baseUrl;
-            this.HttpClient = httpClient;
             this.RequestParameters = new Dictionary<string, IParameter>();
             this.SetPageToken(pageToken);
             this.SetPageSize(pageSize);
@@ -60,14 +59,10 @@ namespace FirebaseAdmin.Util
 
         protected virtual string PageTokenParam => "pageToken";
 
-        protected ErrorHandlingHttpClient<TException> HttpClient { get; }
-
         public async Task<TResult> ExecuteAsync()
         {
             return await this.ExecuteAsync(default).ConfigureAwait(false);
         }
-
-        public abstract Task<TResult> ExecuteAsync(CancellationToken cancellationToken);
 
         public TResult Execute()
         {
@@ -84,13 +79,9 @@ namespace FirebaseAdmin.Util
             return await this.ExecuteAsStreamAsync(default).ConfigureAwait(false);
         }
 
-        public async Task<Stream> ExecuteAsStreamAsync(CancellationToken cancellationToken)
-        {
-            var request = this.CreateRequest();
-            var response = await this.HttpClient.SendAsync(request, cancellationToken)
-                .ConfigureAwait(false);
-            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
-        }
+        public abstract Task<TResult> ExecuteAsync(CancellationToken cancellationToken);
+
+        public abstract Task<Stream> ExecuteAsStreamAsync(CancellationToken cancellationToken);
 
         public virtual HttpRequestMessage CreateRequest(bool? overrideGZipEnabled = null)
         {


### PR DESCRIPTION
* Extending `ListResourcesRequest` for `ListUsers()` and `ListProviderConfigsAsync()` methods.
* Decoupled `ListResourcesRequest` from `ErrorHandlingHttpClient` by introducing a new `AdaptedListResourcesRequest` class.