### PR TITLE
change: Update project target frameworks and dependencies

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractFirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractFirebaseAuthTest.cs
@@ -481,10 +481,10 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             }
 
             var pagedEnumerable = this.Auth.ListUsersAsync(null);
-            var enumerator = pagedEnumerable.GetEnumerator();
+            var enumerator = pagedEnumerable.GetAsyncEnumerator();
 
             var listedUsers = new List<string>();
-            while (await enumerator.MoveNext())
+            while (await enumerator.MoveNextAsync())
             {
                 var uid = enumerator.Current.Uid;
                 if (users.Contains(uid) && !listedUsers.Contains(uid))

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using FirebaseAdmin.Auth;
 using FirebaseAdmin.Auth.Providers;

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
@@ -69,8 +69,8 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             OidcProviderConfig config = null;
 
             var pagedEnumerable = this.auth.ListOidcProviderConfigsAsync(null);
-            var enumerator = pagedEnumerable.GetEnumerator();
-            while (await enumerator.MoveNext())
+            var enumerator = pagedEnumerable.GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
             {
                 if (enumerator.Current.ProviderId == this.providerId)
                 {

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractSamlProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractSamlProviderConfigTest.cs
@@ -75,8 +75,8 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             SamlProviderConfig config = null;
 
             var pagedEnumerable = this.auth.ListSamlProviderConfigsAsync(null);
-            var enumerator = pagedEnumerable.GetEnumerator();
-            while (await enumerator.MoveNext())
+            var enumerator = pagedEnumerable.GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
             {
                 if (enumerator.Current.ProviderId == this.providerId)
                 {

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/TenantManagerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/TenantManagerTest.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using FirebaseAdmin.Auth;
 using FirebaseAdmin.Auth.Multitenancy;

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/TenantManagerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/TenantManagerTest.cs
@@ -63,8 +63,8 @@ namespace FirebaseAdmin.IntegrationTests.Auth
 
             var pagedEnumerable = FirebaseAuth.DefaultInstance.TenantManager
                 .ListTenantsAsync(null);
-            var enumerator = pagedEnumerable.GetEnumerator();
-            while (await enumerator.MoveNext())
+            var enumerator = pagedEnumerable.GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
             {
                 if (enumerator.Current.TenantId == this.fixture.TenantId)
                 {

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -9,10 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Auth" Version="1.40.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/IntegrationTestUtils.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/IntegrationTestUtils.cs
@@ -13,11 +13,7 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
-using System.IO;
-using FirebaseAdmin;
 using Google.Apis.Auth.OAuth2;
-using Google.Apis.Json;
 
 namespace FirebaseAdmin.IntegrationTests
 {

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>../../stylecop_test.ruleset</CodeAnalysisRuleSet>

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>../../stylecop_test.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Apis.Auth" Version="1.40.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.49.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
   </ItemGroup>
 

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAppSnippets.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAppSnippets.cs
@@ -14,7 +14,6 @@
 
 using System;
 // [START using_namespace_decl]
-using FirebaseAdmin;
 using FirebaseAdmin.Auth;
 using Google.Apis.Auth.OAuth2;
 // [END using_namespace_decl]

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAuthSnippets.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAuthSnippets.cs
@@ -498,8 +498,8 @@ namespace FirebaseAdmin.Snippets
             // [START list_all_users]
             // Start listing users from the beginning, 1000 at a time.
             var pagedEnumerable = FirebaseAuth.DefaultInstance.ListUsersAsync(null);
-            var responses = pagedEnumerable.AsRawResponses().GetEnumerator();
-            while (await responses.MoveNext())
+            var responses = pagedEnumerable.AsRawResponses().GetAsyncEnumerator();
+            while (await responses.MoveNextAsync())
             {
                 ExportedUserRecords response = responses.Current;
                 foreach (ExportedUserRecord user in response.Users)
@@ -510,8 +510,8 @@ namespace FirebaseAdmin.Snippets
 
             // Iterate through all users. This will still retrieve users in batches,
             // buffering no more than 1000 users in memory at a time.
-            var enumerator = FirebaseAuth.DefaultInstance.ListUsersAsync(null).GetEnumerator();
-            while (await enumerator.MoveNext())
+            var enumerator = FirebaseAuth.DefaultInstance.ListUsersAsync(null).GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
             {
                 ExportedUserRecord user = enumerator.Current;
                 Console.WriteLine($"User: {user.Uid}");
@@ -756,9 +756,9 @@ namespace FirebaseAdmin.Snippets
             };
             IAsyncEnumerator<SamlProviderConfig> enumerator = FirebaseAuth.DefaultInstance
                 .ListSamlProviderConfigsAsync(listOptions)
-                .GetEnumerator();
+                .GetAsyncEnumerator();
 
-            while (await enumerator.MoveNext())
+            while (await enumerator.MoveNextAsync())
             {
                 SamlProviderConfig saml = enumerator.Current;
                 Console.WriteLine(saml.ProviderId);
@@ -826,9 +826,9 @@ namespace FirebaseAdmin.Snippets
             };
             IAsyncEnumerator<OidcProviderConfig> enumerator = FirebaseAuth.DefaultInstance
                 .ListOidcProviderConfigsAsync(listOptions)
-                .GetEnumerator();
+                .GetAsyncEnumerator();
 
-            while (await enumerator.MoveNext())
+            while (await enumerator.MoveNextAsync())
             {
                 OidcProviderConfig oidc = enumerator.Current;
                 Console.WriteLine(oidc.ProviderId);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 using FirebaseAdmin.Auth.Jwt;
 using Google.Apis.Auth.OAuth2;
 using Xunit;

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantManagerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantManagerTest.cs
@@ -399,8 +399,8 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
             var tenants = new List<Tenant>();
 
             var pagedEnumerable = auth.TenantManager.ListTenantsAsync(null);
-            var enumerator = pagedEnumerable.GetEnumerator();
-            while (await enumerator.MoveNext())
+            var enumerator = pagedEnumerable.GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
             {
                 tenants.Add(enumerator.Current);
             }
@@ -509,8 +509,8 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
             var tokens = new List<string>();
 
             var pagedEnumerable = auth.TenantManager.ListTenantsAsync(null);
-            var responses = pagedEnumerable.AsRawResponses().GetEnumerator();
-            while (await responses.MoveNext())
+            var responses = pagedEnumerable.AsRawResponses().GetAsyncEnumerator();
+            while (await responses.MoveNextAsync())
             {
                 tenants.AddRange(responses.Current.Tenants);
                 tokens.Add(responses.Current.NextPageToken);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -431,8 +431,8 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             var configs = new List<OidcProviderConfig>();
 
             var pagedEnumerable = auth.ListOidcProviderConfigsAsync(null);
-            var enumerator = pagedEnumerable.GetEnumerator();
-            while (await enumerator.MoveNext())
+            var enumerator = pagedEnumerable.GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
             {
                 configs.Add(enumerator.Current);
             }
@@ -528,8 +528,8 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             var tokens = new List<string>();
 
             var pagedEnumerable = auth.ListOidcProviderConfigsAsync(null);
-            var responses = pagedEnumerable.AsRawResponses().GetEnumerator();
-            while (await responses.MoveNext())
+            var responses = pagedEnumerable.AsRawResponses().GetAsyncEnumerator();
+            while (await responses.MoveNextAsync())
             {
                 configs.AddRange(responses.Current.ProviderConfigs);
                 tokens.Add(responses.Current.NextPageToken);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/SamlProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/SamlProviderConfigTest.cs
@@ -426,8 +426,8 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             var configs = new List<SamlProviderConfig>();
 
             var pagedEnumerable = auth.ListSamlProviderConfigsAsync(null);
-            var enumerator = pagedEnumerable.GetEnumerator();
-            while (await enumerator.MoveNext())
+            var enumerator = pagedEnumerable.GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
             {
                 configs.Add(enumerator.Current);
             }
@@ -523,8 +523,8 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             var tokens = new List<string>();
 
             var pagedEnumerable = auth.ListSamlProviderConfigsAsync(null);
-            var responses = pagedEnumerable.AsRawResponses().GetEnumerator();
-            while (await responses.MoveNext())
+            var responses = pagedEnumerable.AsRawResponses().GetAsyncEnumerator();
+            while (await responses.MoveNextAsync())
             {
                 configs.AddRange(responses.Current.ProviderConfigs);
                 tokens.Add(responses.Current.NextPageToken);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/FirebaseUserManagerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/FirebaseUserManagerTest.cs
@@ -443,8 +443,8 @@ namespace FirebaseAdmin.Auth.Users.Tests
             var users = new List<ExportedUserRecord>();
 
             var pagedEnumerable = auth.ListUsersAsync(null);
-            var enumerator = pagedEnumerable.GetEnumerator();
-            while (await enumerator.MoveNext())
+            var enumerator = pagedEnumerable.GetAsyncEnumerator();
+            while (await enumerator.MoveNextAsync())
             {
                 users.Add(enumerator.Current);
                 if (users.Count % 3 == 0)
@@ -649,8 +649,8 @@ namespace FirebaseAdmin.Auth.Users.Tests
             var tokens = new List<string>();
 
             var pagedEnumerable = auth.ListUsersAsync(null);
-            var responses = pagedEnumerable.AsRawResponses().GetEnumerator();
-            while (await responses.MoveNext())
+            var responses = pagedEnumerable.AsRawResponses().GetAsyncEnumerator();
+            while (await responses.MoveNextAsync())
             {
                 users.AddRange(responses.Current.Users);
                 tokens.Add(responses.Current.NextPageToken);
@@ -750,7 +750,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
 
             var pagedEnumerable = auth.ListUsersAsync(null);
             var exception = await Assert.ThrowsAsync<FirebaseAuthException>(
-                async () => await pagedEnumerable.First());
+                async () => await pagedEnumerable.FirstAsync());
 
             Assert.Equal(ErrorCode.Internal, exception.ErrorCode);
             Assert.Null(exception.AuthErrorCode);
@@ -775,16 +775,16 @@ namespace FirebaseAdmin.Auth.Users.Tests
             var auth = config.CreateAuth(handler);
 
             var pagedEnumerable = auth.ListUsersAsync(null);
-            var enumerator = pagedEnumerable.GetEnumerator();
+            var enumerator = pagedEnumerable.GetAsyncEnumerator();
             for (int i = 0; i < 3; i++)
             {
-                Assert.True(await enumerator.MoveNext());
+                Assert.True(await enumerator.MoveNextAsync());
             }
 
             handler.StatusCode = HttpStatusCode.InternalServerError;
             handler.Response = "{}";
             var exception = await Assert.ThrowsAsync<FirebaseAuthException>(
-                async () => await enumerator.MoveNext());
+                async () => await enumerator.MoveNextAsync());
 
             Assert.Equal(ErrorCode.Internal, exception.ErrorCode);
             Assert.Null(exception.AuthErrorCode);
@@ -812,7 +812,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
 
             var pagedEnumerable = auth.ListUsersAsync(null);
             var exception = await Assert.ThrowsAsync<FirebaseAuthException>(
-                async () => await pagedEnumerable.First());
+                async () => await pagedEnumerable.FirstAsync());
 
             Assert.Equal(ErrorCode.Unknown, exception.ErrorCode);
             Assert.Equal(AuthErrorCode.UnexpectedResponse, exception.AuthErrorCode);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/FirebaseUserManagerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/FirebaseUserManagerTest.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using FirebaseAdmin.Auth.Hash;

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>
@@ -11,11 +11,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.6.3" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.40.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Google.Apis.Auth" Version="1.49.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Google.Apis.Json;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Xunit;
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/TopicManagementResponseTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/TopicManagementResponseTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using FirebaseAdmin.Messaging;
 using Newtonsoft.Json;
 using Xunit;

--- a/FirebaseAdmin/FirebaseAdmin/Auth/IUserInfo.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/IUserInfo.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace FirebaseAdmin.Auth
+﻿namespace FirebaseAdmin.Auth
 {
     /// <summary>
     /// A collection of standard profile information for a user. Used to expose profile information

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
@@ -290,10 +290,10 @@ namespace FirebaseAdmin.Auth.Jwt
             var keys = await this.keySource.GetPublicKeysAsync(cancellationToken)
                 .ConfigureAwait(false);
             var verified = keys.Any(key =>
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD2_0
                 key.Id == keyId && key.RSA.VerifyHash(
                     hash, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
-#elif NET45
+#elif NET461
                 key.Id == keyId &&
                     ((RSACryptoServiceProvider)key.RSA).VerifyHash(hash, Sha256Oid, signature)
 #else

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
@@ -290,12 +290,8 @@ namespace FirebaseAdmin.Auth.Jwt
             var keys = await this.keySource.GetPublicKeysAsync(cancellationToken)
                 .ConfigureAwait(false);
             var verified = keys.Any(key =>
-#if NETSTANDARD2_0 || NET461
                 key.Id == keyId && key.RSA.VerifyHash(
                     hash, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
-#else
-#error Unsupported target
-#endif
             );
             if (!verified)
             {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/HttpPublicKeySource.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/HttpPublicKeySource.cs
@@ -23,12 +23,7 @@ using System.Threading.Tasks;
 using FirebaseAdmin.Util;
 using Google.Apis.Http;
 using Google.Apis.Util;
-
-#if NETSTANDARD2_0 || NET461
 using RSAKey = System.Security.Cryptography.RSA;
-#else
-#error Unsupported target
-#endif
 
 namespace FirebaseAdmin.Auth.Jwt
 {
@@ -130,11 +125,7 @@ namespace FirebaseAdmin.Auth.Jwt
             {
                 var x509cert = new X509Certificate2(Encoding.UTF8.GetBytes(entry.Value));
                 RSAKey rsa;
-#if NETSTANDARD2_0 || NET461
                 rsa = x509cert.GetRSAPublicKey();
-#else
-#error Unsupported target
-#endif
                 builder.Add(new PublicKey(entry.Key, rsa));
             }
 

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/HttpPublicKeySource.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/HttpPublicKeySource.cs
@@ -24,9 +24,9 @@ using FirebaseAdmin.Util;
 using Google.Apis.Http;
 using Google.Apis.Util;
 
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD2_0
 using RSAKey = System.Security.Cryptography.RSA;
-#elif NET45
+#elif NET461
 using RSAKey = System.Security.Cryptography.RSACryptoServiceProvider;
 #else
 #error Unsupported target
@@ -132,9 +132,9 @@ namespace FirebaseAdmin.Auth.Jwt
             {
                 var x509cert = new X509Certificate2(Encoding.UTF8.GetBytes(entry.Value));
                 RSAKey rsa;
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD2_0
                 rsa = x509cert.GetRSAPublicKey();
-#elif NET45
+#elif NET461
                 rsa = (RSAKey)x509cert.PublicKey.Key;
 #else
 #error Unsupported target

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/PublicKey.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/PublicKey.cs
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETSTANDARD2_0 || NET461
 using RSAKey = System.Security.Cryptography.RSA;
-#else
-#error Unsupported target
-#endif
 
 namespace FirebaseAdmin.Auth.Jwt
 {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/PublicKey.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/PublicKey.cs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD2_0
 using RSAKey = System.Security.Cryptography.RSA;
-#elif NET45
+#elif NET461
 using RSAKey = System.Security.Cryptography.RSACryptoServiceProvider;
 #else
 #error Unsupported target

--- a/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
@@ -25,8 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax" Version="3.1.0" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="3.1.0" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="3.2.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.49.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">

--- a/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <Version>1.16.0</Version>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>
@@ -25,10 +25,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Google.Api.Gax" Version="2.7.0" />
-    <PackageReference Include="Google.Api.Gax.Rest" Version="2.7.0" />
-    <PackageReference Include="Google.Apis.Auth" Version="1.40.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
+    <PackageReference Include="Google.Api.Gax" Version="3.1.0" />
+    <PackageReference Include="Google.Api.Gax.Rest" Version="3.1.0" />
+    <PackageReference Include="Google.Apis.Auth" Version="1.49.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/FirebaseAdmin/FirebaseAdmin/FirebaseApp.cs
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseApp.cs
@@ -17,7 +17,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Threading.Tasks;
 using Google;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging;

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/ApnsConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/ApnsConfig.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Google.Apis.Json;
 using Newtonsoft.Json;
 
 namespace FirebaseAdmin.Messaging

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/BatchResponse.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/BatchResponse.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Google.Apis.Util;

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/CriticalSound.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/CriticalSound.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace FirebaseAdmin.Messaging

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace FirebaseAdmin.Messaging
 {

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/WebpushConfig.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ We also welcome bug reports, feature requests, and code review feedback.
 
 Admin .NET SDK supports the following frameworks:
 
-* .NET Framework 4.5+
-* netstandard 1.5 and 2.0, providing .NET Core support
+* .NET Framework 4.6.1+
+* .NET Standard 2.0, providing .NET Core support
 
 This is consistent with the frameworks supported by other .NET libraries
 associated with Google Cloud Platform.


### PR DESCRIPTION
 - Project target frameworks replaced with .NET Framework 4.6.1 and .NET Standard 2.0 to be consistent with the frameworks supported by other .NET libraries associated with Google Cloud Platform.
- Removed Google.Api.Gax
- Updated Google.Api.Gax.Rest to 3.2.0
- Updated Google.Apis.Auth to 1.49.0
- Updated System.Collections.Immutable to 1.7.1
- Fixed tests

API CHANGE: Dropped support for `netstandard1.5` and `net45` target frameworks. Developers are now required to use `netstandard2.0` or `net461`.
API CHANGE: Upgraded the dependency `Google.Api.Gax` to the latest major version. Developers that use the [`PagedAsyncEnumerable`](https://googleapis.github.io/google-cloud-dotnet/docs/api/Google.Api.Gax.PagedAsyncEnumerable-2.html) interface from this package (usually as the return value of list iteration API calls), may have to update their implementations accordingly.

Resolves #264 #265 #207