### PR TITLE
chore: Deprecating support for net45 and netstandard1.5

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifier.cs
@@ -290,7 +290,7 @@ namespace FirebaseAdmin.Auth.Jwt
             var keys = await this.keySource.GetPublicKeysAsync(cancellationToken)
                 .ConfigureAwait(false);
             var verified = keys.Any(key =>
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD1_5 || NETSTANDARD2_0 || NET461
                 key.Id == keyId && key.RSA.VerifyHash(
                     hash, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1)
 #elif NET45

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/HttpPublicKeySource.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/HttpPublicKeySource.cs
@@ -24,7 +24,7 @@ using FirebaseAdmin.Util;
 using Google.Apis.Http;
 using Google.Apis.Util;
 
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD1_5 || NETSTANDARD2_0 || NET461
 using RSAKey = System.Security.Cryptography.RSA;
 #elif NET45
 using RSAKey = System.Security.Cryptography.RSACryptoServiceProvider;
@@ -132,7 +132,7 @@ namespace FirebaseAdmin.Auth.Jwt
             {
                 var x509cert = new X509Certificate2(Encoding.UTF8.GetBytes(entry.Value));
                 RSAKey rsa;
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD1_5 || NETSTANDARD2_0 || NET461
                 rsa = x509cert.GetRSAPublicKey();
 #elif NET45
                 rsa = (RSAKey)x509cert.PublicKey.Key;

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/PublicKey.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/PublicKey.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NETSTANDARD1_5 || NETSTANDARD2_0
+#if NETSTANDARD1_5 || NETSTANDARD2_0 || NET461
 using RSAKey = System.Security.Cryptography.RSA;
 #elif NET45
 using RSAKey = System.Security.Cryptography.RSACryptoServiceProvider;

--- a/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>1.16.0</Version>
-    <TargetFrameworks>netstandard1.5;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.5;netstandard2.0;net45;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.5;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/README.md
+++ b/README.md
@@ -59,11 +59,17 @@ We also welcome bug reports, feature requests, and code review feedback.
 
 Admin .NET SDK supports the following frameworks:
 
-* .NET Framework 4.5+
-* netstandard 1.5 and 2.0, providing .NET Core support
+* .NET Framework 4.5+ (4.6.1+ recommended)
+* netstandard 1.5 and 2.0 (2.0 recommended), providing .NET Core support
 
 This is consistent with the frameworks supported by other .NET libraries
 associated with Google Cloud Platform.
+
+Support for .NET Framework 4.5 and netstandard 1.5 is now deprecated.
+Next major version of the Admin SDK will terminate support for these
+frameworks. Developers are advised to upgrade their runtime frameworks
+accordingly.
+
 
 ## Documentation
 


### PR DESCRIPTION
* Added `net461` to the list of target frameworks.
* Added a note indicating that the support `net45` and `netstandard1.5` are on the way out.

Laying the groundwork for #251 

RELEASE NOTE: change: Support for `net45` and `netstandard1.5` frameworks has been deprecated. Developers are advised to use `net461` or `netstandard2.0`. 