### PR TITLE
feat(fcm): Support for sending up to 500 messages in a batch

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseMessagingSnippets.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseMessagingSnippets.cs
@@ -121,7 +121,7 @@ namespace FirebaseAdmin.Snippets
         {
             var registrationToken = "YOUR_REGISTRATION_TOKEN";
             // [START send_all]
-            // Create a list containing up to 100 messages.
+            // Create a list containing up to 500 messages.
             var messages = new List<Message>()
             {
                 new Message()
@@ -154,7 +154,7 @@ namespace FirebaseAdmin.Snippets
         internal static async Task SendMulticastAsync()
         {
             // [START send_multicast]
-            // Create a list containing up to 100 registration tokens.
+            // Create a list containing up to 500 registration tokens.
             // These registration tokens come from the client FCM SDKs.
             var registrationTokens = new List<string>()
             {

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
@@ -380,7 +380,7 @@ Content-Type: application/json; charset=UTF-8
         {
             var factory = new MockHttpClientFactory(new MockMessageHandler());
             var client = this.CreateMessagingClient(factory);
-            var messages = Enumerable.Range(0, 101).Select(_ => new Message { Topic = "test-topic" });
+            var messages = Enumerable.Range(0, 501).Select(_ => new Message { Topic = "test-topic" });
             await Assert.ThrowsAsync<ArgumentException>(() => client.SendAllAsync(messages));
         }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MulticastMessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MulticastMessageTest.cs
@@ -49,7 +49,7 @@ namespace FirebaseAdmin.Tests.Messaging
         {
             var message = new MulticastMessage
             {
-                Tokens = Enumerable.Range(0, 101).Select(x => x.ToString()).ToList(),
+                Tokens = Enumerable.Range(0, 501).Select(x => x.ToString()).ToList(),
             };
 
             Assert.Throws<ArgumentException>(() => message.GetMessageList());

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessagingClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessagingClient.cs
@@ -150,9 +150,9 @@ namespace FirebaseAdmin.Messaging
                 throw new ArgumentException("At least one message is required.");
             }
 
-            if (copyOfMessages.Count > 100)
+            if (copyOfMessages.Count > 500)
             {
-                throw new ArgumentException("At most 100 messages are allowed.");
+                throw new ArgumentException("At most 500 messages are allowed.");
             }
 
             try

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
@@ -21,7 +21,7 @@ namespace FirebaseAdmin.Messaging
     /// <summary>
     /// Represents a message that can be sent to multiple devices via Firebase Cloud Messaging (FCM).
     /// Contains payload information as well as the list of device registration tokens to which the
-    /// message should be sent. A single <c>MulticastMessage</c> may contain up to 100 registration
+    /// message should be sent. A single <c>MulticastMessage</c> may contain up to 500 registration
     /// tokens.
     /// </summary>
     public sealed class MulticastMessage
@@ -61,9 +61,9 @@ namespace FirebaseAdmin.Messaging
         {
             var tokens = this.Tokens;
 
-            if (tokens == null || tokens.Count > 100)
+            if (tokens == null || tokens.Count > 500)
             {
-                throw new ArgumentException("Tokens must be non-null and contain at most 100 tokens.");
+                throw new ArgumentException("Tokens must be non-null and contain at most 500 tokens.");
             }
 
             var tokensCopy = new List<string>(tokens);


### PR DESCRIPTION
RELEASE NOTE: `MulticastMessage` and `SendAllAsync()` APIs now support sending up to 500 messages in a batch.