### PR TITLE
fix(fcm): Setting ApplicationName property for the batch client

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
@@ -194,6 +194,8 @@ Vary: Referer
             Assert.Equal("projects/fir-adminintegrationtests/messages/5903525881088369386", response.Responses[1].MessageId);
             Assert.Equal(1, handler.Calls);
 
+            var userAgent = handler.LastRequestHeaders.UserAgent.First();
+            Assert.Equal("fire-admin-dotnet", userAgent.Product.Name);
             Assert.Equal(2, this.CountLinesWithPrefix(handler.LastRequestBody, VersionHeader));
             Assert.Equal(2, this.CountLinesWithPrefix(handler.LastRequestBody, ApiFormatHeader));
         }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessagingClient.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessagingClient.cs
@@ -68,6 +68,7 @@ namespace FirebaseAdmin.Messaging
             {
                 HttpClientFactory = args.ClientFactory,
                 HttpClientInitializer = args.Credential,
+                ApplicationName = ClientVersion,
             });
             this.sendUrl = string.Format(FcmSendUrl, args.ProjectId);
             this.restPath = this.sendUrl.Substring(FcmBaseUrl.Length);


### PR DESCRIPTION
RELEASE NOTE: Setting the `ApplicationName` property for the batch request client, which resolves a warning log message seen in previous versions of the SDK.

Resolves #259 