### PR TITLE
feat(auth): Supporting VerifyIdToken() API with emulator

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
@@ -120,8 +120,13 @@ namespace FirebaseAdmin.Auth.Tests
 
         private FirebaseTokenVerifier CreateIdTokenVerifier()
         {
-            return FirebaseTokenVerifier.CreateIdTokenVerifier(
-                this.ProjectId, this.KeySource, this.Clock, this.TenantId);
+            var args = FirebaseTokenVerifier.CreateIdTokenVerifierArgs();
+            args.ProjectId = this.ProjectId;
+            args.PublicKeySource = this.KeySource;
+            args.Clock = this.Clock;
+            args.TenantId = this.TenantId;
+            args.IsEmulatorMode = !string.IsNullOrWhiteSpace(this.EmulatorHost);
+            return new FirebaseTokenVerifier(args);
         }
 
         private FirebaseTokenVerifier CreateSessionCookieVerifier()

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthEmulatorTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthEmulatorTest.cs
@@ -31,7 +31,7 @@ namespace FirebaseAdmin.Auth.Tests
         }
 
         [Fact]
-        public void UserManager()
+        public void DefaultFirebaseAuth()
         {
             var app = FirebaseApp.Create(new AppOptions
             {
@@ -39,11 +39,25 @@ namespace FirebaseAdmin.Auth.Tests
                 ProjectId = "project1",
             });
 
-            var userManager = FirebaseAuth.DefaultInstance.UserManager;
+            var auth = FirebaseAuth.DefaultInstance;
 
-            Assert.Equal("project1", userManager.ProjectId);
-            Assert.Null(userManager.TenantId);
-            Assert.Equal("localhost:9090", userManager.EmulatorHost);
+            Assert.Equal("localhost:9090", auth.UserManager.EmulatorHost);
+            Assert.True(auth.IdTokenVerifier.IsEmulatorMode);
+        }
+
+        [Fact]
+        public void TenantAwareFirebseAuth()
+        {
+            var app = FirebaseApp.Create(new AppOptions
+            {
+                Credential = MockCredential,
+                ProjectId = "project1",
+            });
+
+            var auth = FirebaseAuth.DefaultInstance.TenantManager.AuthForTenant("tenant1");
+
+            Assert.Equal("localhost:9090", auth.UserManager.EmulatorHost);
+            Assert.True(auth.IdTokenVerifier.IsEmulatorMode);
         }
 
         public virtual void Dispose()

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -85,6 +85,21 @@ namespace FirebaseAdmin.Auth.Tests
         }
 
         [Fact]
+        public void NoEmulator()
+        {
+            var app = FirebaseApp.Create(new AppOptions
+            {
+                Credential = MockCredential,
+                ProjectId = "project1",
+            });
+
+            FirebaseAuth auth = FirebaseAuth.DefaultInstance;
+
+            Assert.False(auth.IdTokenVerifier.IsEmulatorMode);
+            Assert.Null(auth.UserManager.EmulatorHost);
+        }
+
+        [Fact]
         public void UserManagerNoProjectId()
         {
             FirebaseApp.Create(new AppOptions() { Credential = MockCredential });
@@ -135,22 +150,6 @@ namespace FirebaseAdmin.Auth.Tests
             var tokenFactory = FirebaseAuth.DefaultInstance.TokenFactory;
 
             Assert.IsType<FixedAccountIAMSigner>(tokenFactory.Signer);
-        }
-
-        [Fact]
-        public void UserManager()
-        {
-            var app = FirebaseApp.Create(new AppOptions
-            {
-                Credential = MockCredential,
-                ProjectId = "project1",
-            });
-
-            var userManager = FirebaseAuth.DefaultInstance.UserManager;
-
-            Assert.Equal("project1", userManager.ProjectId);
-            Assert.Null(userManager.TenantId);
-            Assert.Null(userManager.EmulatorHost);
         }
 
         public void Dispose()

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/JwtTestUtils.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/JwtTestUtils.cs
@@ -81,9 +81,18 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
 
         public static void AssertRevocationCheckRequest(string tenantId, Uri uri)
         {
-            var tenantInfo = tenantId != null ? $"/tenants/{tenantId}" : string.Empty;
-            var expectedPath = $"/v1/projects/{ProjectId}{tenantInfo}/accounts:lookup";
-            Assert.Equal(expectedPath, uri.PathAndQuery);
+            AssertRevocationCheckRequest(tenantId, null, uri);
+        }
+
+        public static void AssertRevocationCheckRequest(string tenantId, string emulatorHost, Uri uri)
+        {
+            var options = new Utils.UrlOptions
+            {
+                TenantId = tenantId,
+                EmulatorHost = emulatorHost,
+            };
+            var expectedUrl = $"{Utils.BuildAuthUrl(ProjectId, options)}/accounts:lookup";
+            Assert.Equal(expectedUrl, uri.ToString());
         }
 
         private static ISigner CreateTestSigner(string filePath)

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
@@ -66,6 +66,17 @@ namespace FirebaseAdmin.Auth.Multitenancy
             Assert.Equal(MockTenantId, auth.ProviderConfigManager.TenantId);
         }
 
+        [Fact]
+        public void Emulator()
+        {
+            var app = CreateFirebaseApp();
+
+            var auth = FirebaseAuth.DefaultInstance.TenantManager.AuthForTenant(MockTenantId);
+
+            Assert.False(auth.IdTokenVerifier.IsEmulatorMode);
+            Assert.Null(auth.UserManager.EmulatorHost);
+        }
+
         public void Dispose()
         {
             FirebaseApp.DeleteAll();

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifierArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/FirebaseTokenVerifierArgs.cs
@@ -36,6 +36,8 @@ namespace FirebaseAdmin.Auth.Jwt
 
         public AuthErrorCode InvalidTokenCode { get; set; }
 
+        public bool IsEmulatorMode { get; set; }
+
         public AuthErrorCode ExpiredTokenCode { get; set; }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Utils.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Utils.cs
@@ -24,6 +24,9 @@ namespace FirebaseAdmin.Auth
         internal static string EmulatorHostFromEnvironment =>
             Environment.GetEnvironmentVariable("FIREBASE_AUTH_EMULATOR_HOST");
 
+        internal static bool IsEmulatorModeFromEnvironment =>
+            !string.IsNullOrWhiteSpace(EmulatorHostFromEnvironment);
+
         internal static string BuildAuthUrl(string projectId, UrlOptions options = null)
         {
             var version = !string.IsNullOrEmpty(options?.ApiVersion) ? options.ApiVersion : "v1";


### PR DESCRIPTION
Added emulator support for `VerifyIdTokenAsync()` method. In the emulator mode:

* Algorithm and KID header validations are skipped
* Signature verification is skipped