### PR TITLE
feat(auth): Emulator support for CreateCustomTokenAsync() API

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
@@ -43,6 +43,8 @@ namespace FirebaseAdmin.Auth.Tests
 
         internal string EmulatorHost { get; set; }
 
+        internal ISigner Signer { get; set; }
+
         public AbstractFirebaseAuth Build(TestOptions options)
         {
             if (this.TenantId != null)
@@ -90,6 +92,11 @@ namespace FirebaseAdmin.Auth.Tests
                         $"Session cookie verification not supported on {args.GetType()}");
                 }
             }
+
+            if (options.TokenFactory)
+            {
+                args.TokenFactory = new Lazy<FirebaseTokenFactory>(this.CreateTokenFactory());
+            }
         }
 
         private FirebaseUserManager CreateUserManager(TestOptions options)
@@ -133,6 +140,18 @@ namespace FirebaseAdmin.Auth.Tests
         {
             return FirebaseTokenVerifier.CreateSessionCookieVerifier(
                 this.ProjectId, this.KeySource, this.Clock);
+        }
+
+        private FirebaseTokenFactory CreateTokenFactory()
+        {
+            var args = new FirebaseTokenFactory.Args
+            {
+                Signer = this.Signer,
+                Clock = this.Clock,
+                TenantId = this.TenantId,
+                IsEmulatorMode = !string.IsNullOrWhiteSpace(this.EmulatorHost),
+            };
+            return new FirebaseTokenFactory(args);
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthEmulatorTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthEmulatorTest.cs
@@ -43,6 +43,7 @@ namespace FirebaseAdmin.Auth.Tests
 
             Assert.Equal("localhost:9090", auth.UserManager.EmulatorHost);
             Assert.True(auth.IdTokenVerifier.IsEmulatorMode);
+            Assert.True(auth.TokenFactory.IsEmulatorMode);
         }
 
         [Fact]
@@ -58,6 +59,7 @@ namespace FirebaseAdmin.Auth.Tests
 
             Assert.Equal("localhost:9090", auth.UserManager.EmulatorHost);
             Assert.True(auth.IdTokenVerifier.IsEmulatorMode);
+            Assert.True(auth.TokenFactory.IsEmulatorMode);
         }
 
         public virtual void Dispose()

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -93,7 +93,7 @@ namespace FirebaseAdmin.Auth.Tests
                 ProjectId = "project1",
             });
 
-            FirebaseAuth auth = FirebaseAuth.DefaultInstance;
+            var auth = FirebaseAuth.DefaultInstance;
 
             Assert.False(auth.TokenFactory.IsEmulatorMode);
             Assert.False(auth.IdTokenVerifier.IsEmulatorMode);
@@ -137,6 +137,57 @@ namespace FirebaseAdmin.Auth.Tests
             Assert.Equal(
                 "Must initialize FirebaseApp with a project ID to manage tenants.",
                 ex.Message);
+        }
+
+        [Fact]
+        public void ServiceAccountCredential()
+        {
+            var options = new AppOptions
+            {
+                Credential = GoogleCredential.FromFile("./resources/service_account.json"),
+            };
+            var app = FirebaseApp.Create(options);
+
+            var tokenFactory = FirebaseAuth.DefaultInstance.TokenFactory;
+
+            Assert.IsType<ServiceAccountSigner>(tokenFactory.Signer);
+        }
+
+        [Fact]
+        public void ServiceAccountId()
+        {
+            var options = new AppOptions
+            {
+                Credential = MockCredential,
+                ServiceAccountId = "test-service-account",
+            };
+            var app = FirebaseApp.Create(options);
+
+            var tokenFactory = FirebaseAuth.DefaultInstance.TokenFactory;
+
+            Assert.IsType<FixedAccountIAMSigner>(tokenFactory.Signer);
+        }
+
+        [Fact]
+        public async void InvalidCredential()
+        {
+            var options = new AppOptions
+            {
+                Credential = MockCredential,
+            };
+            var app = FirebaseApp.Create(options);
+
+            var tokenFactory = FirebaseAuth.DefaultInstance.TokenFactory;
+
+            Assert.IsType<IAMSigner>(tokenFactory.Signer);
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => FirebaseAuth.DefaultInstance.CreateCustomTokenAsync("user1"));
+            var errorMessage = "Failed to determine service account ID. Make sure to initialize the SDK "
+                + "with service account credentials or specify a service account "
+                + "ID with iam.serviceAccounts.signBlob permission. Please refer to "
+                + "https://firebase.google.com/docs/auth/admin/create-custom-tokens for "
+                + "more details on creating custom tokens.";
+            Assert.Equal(errorMessage, ex.Message);
         }
 
         public void Dispose()

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/FirebaseAuthTest.cs
@@ -95,6 +95,7 @@ namespace FirebaseAdmin.Auth.Tests
 
             FirebaseAuth auth = FirebaseAuth.DefaultInstance;
 
+            Assert.False(auth.TokenFactory.IsEmulatorMode);
             Assert.False(auth.IdTokenVerifier.IsEmulatorMode);
             Assert.Null(auth.UserManager.EmulatorHost);
         }
@@ -136,20 +137,6 @@ namespace FirebaseAdmin.Auth.Tests
             Assert.Equal(
                 "Must initialize FirebaseApp with a project ID to manage tenants.",
                 ex.Message);
-        }
-
-        [Fact]
-        public void ServiceAccountId()
-        {
-            FirebaseApp.Create(new AppOptions
-            {
-                Credential = MockCredential,
-                ServiceAccountId = "test-service-account",
-            });
-
-            var tokenFactory = FirebaseAuth.DefaultInstance.TokenFactory;
-
-            Assert.IsType<FixedAccountIAMSigner>(tokenFactory.Signer);
         }
 
         public void Dispose()

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/CustomTokenTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/CustomTokenTest.cs
@@ -16,17 +16,20 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using FirebaseAdmin.Auth.Tests;
 using Google.Apis.Auth.OAuth2;
 using Xunit;
 
 namespace FirebaseAdmin.Auth.Jwt.Tests
 {
-    public class CustomTokenTest : IDisposable
+    public class CustomTokenTest
     {
         public static readonly IEnumerable<object[]> TestConfigs = new List<object[]>()
         {
-            new object[] { FirebaseAuthTestConfig.DefaultInstance },
-            new object[] { TenantAwareFirebaseAuthTestConfig.DefaultInstance },
+            new object[] { TestConfig.ForFirebaseAuth() },
+            new object[] { TestConfig.ForTenantAwareFirebaseAuth("tenant1") },
+            new object[] { TestConfig.ForFirebaseAuth().ForEmulator() },
+            new object[] { TestConfig.ForTenantAwareFirebaseAuth("tenant1").ForEmulator() },
         };
 
         [Theory]
@@ -66,78 +69,67 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
                 () => auth.CreateCustomTokenAsync("user1", canceller.Token));
         }
 
-        [Theory]
-        [MemberData(nameof(TestConfigs))]
-        public async Task CreateCustomTokenInvalidCredential(TestConfig config)
+        public class TestConfig
         {
-            var options = new AppOptions
+            private static readonly ServiceAccountCredential DefaultServiceAccount =
+                GoogleCredential.FromFile("./resources/service_account.json").ToServiceAccountCredential();
+
+            private readonly AuthBuilder authBuilder;
+            private readonly CustomTokenVerifier tokenVerifier;
+
+            private TestConfig(AuthBuilder authBuilder, CustomTokenVerifier tokenVerifier)
             {
-                Credential = GoogleCredential.FromAccessToken("test-token"),
-                ProjectId = "project1",
-            };
-            var auth = config.CreateAuth(options);
+                this.authBuilder = authBuilder;
+                this.tokenVerifier = tokenVerifier;
+            }
 
-            var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-                () => auth.CreateCustomTokenAsync("user1"));
+            public string TenantId => this.authBuilder.TenantId;
 
-            var errorMessage = "Failed to determine service account ID. Make sure to initialize the SDK "
-                + "with service account credentials or specify a service account "
-                + "ID with iam.serviceAccounts.signBlob permission. Please refer to "
-                + "https://firebase.google.com/docs/auth/admin/create-custom-tokens for "
-                + "more details on creating custom tokens.";
-            Assert.Equal(errorMessage, ex.Message);
-        }
-
-        public void Dispose()
-        {
-            FirebaseApp.DeleteAll();
-        }
-
-        public abstract class TestConfig
-        {
-            protected static readonly AppOptions DefaultOptions = new AppOptions
+            public static TestConfig ForFirebaseAuth()
             {
-                Credential = GoogleCredential.FromFile("./resources/service_account.json"),
-            };
+                var authBuilder = new AuthBuilder
+                {
+                    Signer = new ServiceAccountSigner(DefaultServiceAccount),
+                };
+                var tokenVerifier = CustomTokenVerifier.FromDefaultServiceAccount();
+                return new TestConfig(authBuilder, tokenVerifier);
+            }
 
-            internal abstract CustomTokenVerifier TokenVerifier { get; }
+            public static TestConfig ForTenantAwareFirebaseAuth(string tenantId)
+            {
+                var authBuilder = new AuthBuilder
+                {
+                    TenantId = tenantId,
+                    Signer = new ServiceAccountSigner(DefaultServiceAccount),
+                };
+                var tokenVerifier = CustomTokenVerifier.FromDefaultServiceAccount(tenantId);
+                return new TestConfig(authBuilder, tokenVerifier);
+            }
 
-            internal abstract AbstractFirebaseAuth CreateAuth(AppOptions options = null);
+            internal TestConfig ForEmulator()
+            {
+                var authBuilder = new AuthBuilder
+                {
+                    TenantId = this.TenantId,
+                    EmulatorHost = "localhost:9090",
+                };
+                var tokenVerifier = CustomTokenVerifier.ForEmulator(this.TenantId);
+                return new TestConfig(authBuilder, tokenVerifier);
+            }
+
+            internal AbstractFirebaseAuth CreateAuth()
+            {
+                var options = new TestOptions
+                {
+                    TokenFactory = true,
+                };
+                return this.authBuilder.Build(options);
+            }
 
             internal void AssertCustomToken(
                 string token, string uid, Dictionary<string, object> claims = null)
             {
-                this.TokenVerifier.Verify(token, uid, claims);
-            }
-        }
-
-        private sealed class FirebaseAuthTestConfig : TestConfig
-        {
-            internal static readonly FirebaseAuthTestConfig DefaultInstance =
-                new FirebaseAuthTestConfig();
-
-            internal override CustomTokenVerifier TokenVerifier =>
-                CustomTokenVerifier.FromDefaultServiceAccount();
-
-            internal override AbstractFirebaseAuth CreateAuth(AppOptions options = null)
-            {
-                FirebaseApp.Create(options ?? DefaultOptions);
-                return FirebaseAuth.DefaultInstance;
-            }
-        }
-
-        private sealed class TenantAwareFirebaseAuthTestConfig : TestConfig
-        {
-            internal static readonly TenantAwareFirebaseAuthTestConfig DefaultInstance =
-                new TenantAwareFirebaseAuthTestConfig();
-
-            internal override CustomTokenVerifier TokenVerifier =>
-                CustomTokenVerifier.FromDefaultServiceAccount("tenant1");
-
-            internal override AbstractFirebaseAuth CreateAuth(AppOptions options = null)
-            {
-                FirebaseApp.Create(options ?? DefaultOptions);
-                return FirebaseAuth.DefaultInstance.TenantManager.AuthForTenant("tenant1");
+                this.tokenVerifier.Verify(token, uid, claims);
             }
         }
     }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/CustomTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/CustomTokenVerifier.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Collections.Generic;
-using System.IO;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -24,11 +23,6 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
 {
     internal abstract class CustomTokenVerifier
     {
-        private const string ClientEmail = "client@test-project.iam.gserviceaccount.com";
-
-        private static readonly byte[] PublicKey =
-            File.ReadAllBytes("./resources/public_cert.pem");
-
         private readonly string issuer;
         private readonly string tenantId;
 
@@ -38,9 +32,10 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
             this.tenantId = tenantId;
         }
 
-        internal static CustomTokenVerifier FromDefaultServiceAccount(string tenantId = null)
+        internal static CustomTokenVerifier ForServiceAccount(
+            string clientEmail, byte[] publicKey, string tenantId = null)
         {
-            return new RSACustomTokenVerifier(ClientEmail, PublicKey, tenantId);
+            return new RSACustomTokenVerifier(clientEmail, publicKey, tenantId);
         }
 
         internal static CustomTokenVerifier ForEmulator(string tenantId = null)

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/CustomTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/CustomTokenVerifier.cs
@@ -17,6 +17,7 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Google.Apis.Auth;
 using Xunit;
 
 namespace FirebaseAdmin.Auth.Jwt.Tests
@@ -42,14 +43,23 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
             return new RSACustomTokenVerifier(ClientEmail, PublicKey, tenantId);
         }
 
+        internal static CustomTokenVerifier ForEmulator(string tenantId = null)
+        {
+            return new EmulatorCustomTokenVerifier(tenantId);
+        }
+
         internal void Verify(string token, string uid, IDictionary<string, object> claims = null)
         {
             string[] segments = token.Split(".");
             Assert.Equal(3, segments.Length);
 
+            var header = JwtUtils.Decode<JsonWebSignature.Header>(segments[0]);
+            this.AssertHeader(header);
+
             var payload = JwtUtils.Decode<FirebaseTokenFactory.CustomTokenPayload>(segments[1]);
             Assert.Equal(this.issuer, payload.Issuer);
             Assert.Equal(this.issuer, payload.Subject);
+            Assert.Equal(FirebaseTokenFactory.FirebaseAudience, payload.Audience);
             Assert.Equal(uid, payload.Uid);
             if (claims == null)
             {
@@ -78,6 +88,12 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
             this.AssertSignature($"{segments[0]}.{segments[1]}", segments[2]);
         }
 
+        protected virtual void AssertHeader(JsonWebSignature.Header header)
+        {
+            Assert.Equal("RS256", header.Algorithm);
+            Assert.Equal("JWT", header.Type);
+        }
+
         protected abstract void AssertSignature(string tokenData, string signature);
 
         private sealed class RSACustomTokenVerifier : CustomTokenVerifier
@@ -101,6 +117,23 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
                     HashAlgorithmName.SHA256,
                     RSASignaturePadding.Pkcs1);
                 Assert.True(verified);
+            }
+        }
+
+        private sealed class EmulatorCustomTokenVerifier : CustomTokenVerifier
+        {
+            internal EmulatorCustomTokenVerifier(string tenantId)
+            : base("firebase-auth-emulator@example.com", tenantId) { }
+
+            protected override void AssertHeader(JsonWebSignature.Header header)
+            {
+                Assert.Equal("none", header.Algorithm);
+                Assert.Equal("JWT", header.Type);
+            }
+
+            protected override void AssertSignature(string tokenData, string signature)
+            {
+                Assert.Empty(signature);
             }
         }
     }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/IdTokenVerificationTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/IdTokenVerificationTest.cs
@@ -576,6 +576,7 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
             {
                 var config = new TestConfig(this.TenantId);
                 config.authBuilder.EmulatorHost = "localhost:9090";
+                config.tokenBuilder.Signer = EmulatorSigner.Instance;
                 return config;
             }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/MockTokenBuilder.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/MockTokenBuilder.cs
@@ -37,9 +37,10 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
             IDictionary<string, object> headerOverrides = null,
             IDictionary<string, object> payloadOverrides = null)
         {
+            var signer = this.Signer.ThrowIfNull(nameof(this.Signer));
             var header = new Dictionary<string, object>()
             {
-                { "alg", "RS256" },
+                { "alg", signer.Algorithm },
                 { "typ", "jwt" },
                 { "kid", "test-key-id" },
             };
@@ -79,7 +80,6 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
                 }
             }
 
-            var signer = this.Signer.ThrowIfNull(nameof(this.Signer));
             return await JwtUtils.CreateSignedJwtAsync(header, payload, signer);
         }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantAwareFirebaseAuthTest.cs
@@ -67,12 +67,13 @@ namespace FirebaseAdmin.Auth.Multitenancy
         }
 
         [Fact]
-        public void Emulator()
+        public void NoEmulator()
         {
             var app = CreateFirebaseApp();
 
             var auth = FirebaseAuth.DefaultInstance.TenantManager.AuthForTenant(MockTenantId);
 
+            Assert.False(auth.TokenFactory.IsEmulatorMode);
             Assert.False(auth.IdTokenVerifier.IsEmulatorMode);
             Assert.Null(auth.UserManager.EmulatorHost);
         }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/TestOptions.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/TestOptions.cs
@@ -30,5 +30,7 @@ namespace FirebaseAdmin.Auth.Tests
         public bool IdTokenVerifier { get; set; }
 
         public bool SessionCookieVerifier { get; set; }
+
+        public bool TokenFactory { get; set; }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/EmulatorSigner.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/EmulatorSigner.cs
@@ -1,0 +1,42 @@
+// Copyright 2021`, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FirebaseAdmin.Auth.Jwt
+{
+    internal sealed class EmulatorSigner : ISigner
+    {
+        internal static readonly EmulatorSigner Instance = new EmulatorSigner();
+
+        private EmulatorSigner() { }
+
+        public string Algorithm => "none";
+
+        public Task<string> GetKeyIdAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult("firebase-auth-emulator@example.com");
+        }
+
+        public Task<byte[]> SignDataAsync(byte[] data, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new byte[] { });
+        }
+
+        public void Dispose() { }
+    }
+}

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/EmulatorSigner.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/EmulatorSigner.cs
@@ -1,4 +1,4 @@
-// Copyright 2021`, Google Inc. All rights reserved.
+// Copyright 2021, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/IAMSigner.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/IAMSigner.cs
@@ -60,6 +60,8 @@ namespace FirebaseAdmin.Auth.Jwt
                     .ConfigureAwait(false), true);
         }
 
+        public string Algorithm => JwtUtils.AlgorithmRS256;
+
         public async Task<byte[]> SignDataAsync(
             byte[] data, CancellationToken cancellationToken = default(CancellationToken))
         {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/ISigner.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/ISigner.cs
@@ -25,6 +25,11 @@ namespace FirebaseAdmin.Auth.Jwt
     internal interface ISigner : IDisposable
     {
         /// <summary>
+        /// Gets the name of the algorithm used to sign data.
+        /// </summary>
+        string Algorithm { get; }
+
+        /// <summary>
         /// Returns the ID (client email) of the service account used to sign payloads.
         /// </summary>
         /// <returns>A task that completes with the key ID string.</returns>

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/JwtUtils.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/JwtUtils.cs
@@ -25,6 +25,8 @@ namespace FirebaseAdmin.Auth.Jwt
     /// </summary>
     internal static class JwtUtils
     {
+        internal const string AlgorithmRS256 = "RS256";
+
         /// <summary>
         /// Decodes a single JWT segment, and deserializes it into a value of type
         /// <typeparamref name="T"/>.

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/ServiceAccountSigner.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Jwt/ServiceAccountSigner.cs
@@ -33,6 +33,8 @@ namespace FirebaseAdmin.Auth.Jwt
             this.credential = credential.ThrowIfNull(nameof(credential));
         }
 
+        public string Algorithm => JwtUtils.AlgorithmRS256;
+
         public Task<string> GetKeyIdAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(this.credential.Id);


### PR DESCRIPTION
Implemented support for creating custom tokens for the emulator. In the emulator mode:

* The `alg` header is set to `none`.
* Signature is set to empty byte sequence.

Bulk of the changes are just refactoring the existing tests. I've updated `CustomTokenTest` to be more inline with other test classes like `IdTokenVerificationTest`, where we test behavior via parameterization, as opposed to creating `FirebaseApp` instances with different configurations.