### PR TITLE
fix(auth): adds missing EMAIL_NOT_FOUND error code

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthErrorHandlerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthErrorHandlerTest.cs
@@ -57,6 +57,12 @@ namespace FirebaseAdmin.Auth.Tests
                     ErrorCode.NotFound,
                     AuthErrorCode.UserNotFound,
                 },
+                new object[]
+                {
+                    "EMAIL_NOT_FOUND",
+                    ErrorCode.NotFound,
+                    AuthErrorCode.EmailNotFound,
+                },
             };
 
         [Theory]

--- a/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorCode.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorCode.cs
@@ -30,13 +30,6 @@ namespace FirebaseAdmin.Auth
         EmailAlreadyExists,
 
         /// <summary>
-        /// No user record found for the given email, typically raised when
-        /// generating a password reset link using an email for a user that
-        /// is not already registered.
-        /// </summary>
-        EmailNotFound,
-
-        /// <summary>
         /// The specified ID token is expired.
         /// </summary>
         ExpiredIdToken,
@@ -105,5 +98,12 @@ namespace FirebaseAdmin.Auth
         /// Tenant ID in a token does not match.
         /// </summary>
         TenantIdMismatch,
+
+        /// <summary>
+        /// No user record found for the given email, typically raised when
+        /// generating a password reset link using an email for a user that
+        /// is not already registered.
+        /// </summary>
+        EmailNotFound,
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorCode.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorCode.cs
@@ -30,6 +30,13 @@ namespace FirebaseAdmin.Auth
         EmailAlreadyExists,
 
         /// <summary>
+        /// No user record found for the given email, typically raised when
+        /// generating a password reset link using an email for a user that
+        /// is not already registered.
+        /// </summary>
+        EmailNotFound,
+
+        /// <summary>
         /// The specified ID token is expired.
         /// </summary>
         ExpiredIdToken,

--- a/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorHandler.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorHandler.cs
@@ -64,6 +64,13 @@ namespace FirebaseAdmin.Auth
                         "The user with the provided email already exists")
                 },
                 {
+                    "EMAIL_NOT_FOUND",
+                    new ErrorInfo(
+                        ErrorCode.NotFound,
+                        AuthErrorCode.EmailNotFound,
+                        "No user record found for the given email")
+                },
+                {
                     "INVALID_DYNAMIC_LINK_DOMAIN",
                     new ErrorInfo(
                         ErrorCode.InvalidArgument,


### PR DESCRIPTION
Catch EMAIL_NOT_FOUND when /accounts:sendOobCode is called for password reset on a user that does not exist.