### PR TITLE
feat(auth): enables OIDC auth code flow

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
@@ -46,6 +46,9 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.True(config.Enabled);
             Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
             Assert.Equal("https://oidc.com/issuer", config.Issuer);
+            Assert.Equal("OIDC_CLIENT_SECRET", config.ClientSecret);
+            Assert.True(config.ResponseType.Code);
+            Assert.Null(config.ResponseType.IDToken);
         }
 
         [Fact]
@@ -59,6 +62,9 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.True(config.Enabled);
             Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
             Assert.Equal("https://oidc.com/issuer", config.Issuer);
+            Assert.Equal("OIDC_CLIENT_SECRET", config.ClientSecret);
+            Assert.True(config.ResponseType.Code);
+            Assert.Null(config.ResponseType.IDToken);
         }
 
         [Fact]
@@ -84,6 +90,9 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.True(config.Enabled);
             Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
             Assert.Equal("https://oidc.com/issuer", config.Issuer);
+            Assert.Equal("OIDC_CLIENT_SECRET", config.ClientSecret);
+            Assert.True(config.ResponseType.Code);
+            Assert.Null(config.ResponseType.IDToken);
         }
 
         [Fact]
@@ -97,6 +106,9 @@ namespace FirebaseAdmin.IntegrationTests.Auth
                 Enabled = false,
                 ClientId = "UPDATED_OIDC_CLIENT_ID",
                 Issuer = "https://oidc.com/updated-issuer",
+                ClientSecret = "UPDATED_OIDC_CLIENT_SECRET",
+                CodeResponseType = false,
+                IDTokenResponseType = true,
             };
 
             var config = await this.auth.UpdateProviderConfigAsync(args);
@@ -106,6 +118,9 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.False(config.Enabled);
             Assert.Equal("UPDATED_OIDC_CLIENT_ID", config.ClientId);
             Assert.Equal("https://oidc.com/updated-issuer", config.Issuer);
+            Assert.Equal("UPDATED_OIDC_CLIENT_SECRET", config.ClientSecret);
+            Assert.Null(config.ResponseType.Code);
+            Assert.True(config.ResponseType.IDToken);
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
@@ -47,8 +47,8 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
             Assert.Equal("https://oidc.com/issuer", config.Issuer);
             Assert.Equal("OIDC_CLIENT_SECRET", config.ClientSecret);
-            Assert.True(config.ResponseType.Code);
-            Assert.Null(config.ResponseType.IDToken);
+            Assert.True(config.CodeResponseType);
+            Assert.False(config.IDTokenResponseType);
         }
 
         [Fact]
@@ -63,8 +63,8 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
             Assert.Equal("https://oidc.com/issuer", config.Issuer);
             Assert.Equal("OIDC_CLIENT_SECRET", config.ClientSecret);
-            Assert.True(config.ResponseType.Code);
-            Assert.Null(config.ResponseType.IDToken);
+            Assert.True(config.CodeResponseType);
+            Assert.False(config.IDTokenResponseType);
         }
 
         [Fact]
@@ -91,8 +91,8 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.Equal("OIDC_CLIENT_ID", config.ClientId);
             Assert.Equal("https://oidc.com/issuer", config.Issuer);
             Assert.Equal("OIDC_CLIENT_SECRET", config.ClientSecret);
-            Assert.True(config.ResponseType.Code);
-            Assert.Null(config.ResponseType.IDToken);
+            Assert.True(config.CodeResponseType);
+            Assert.False(config.IDTokenResponseType);
         }
 
         [Fact]
@@ -119,8 +119,8 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.Equal("UPDATED_OIDC_CLIENT_ID", config.ClientId);
             Assert.Equal("https://oidc.com/updated-issuer", config.Issuer);
             Assert.Equal("UPDATED_OIDC_CLIENT_SECRET", config.ClientSecret);
-            Assert.Null(config.ResponseType.Code);
-            Assert.True(config.ResponseType.IDToken);
+            Assert.False(config.CodeResponseType);
+            Assert.True(config.IDTokenResponseType);
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractOidcProviderConfigTest.cs
@@ -48,7 +48,7 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.Equal("https://oidc.com/issuer", config.Issuer);
             Assert.Equal("OIDC_CLIENT_SECRET", config.ClientSecret);
             Assert.True(config.CodeResponseType);
-            Assert.False(config.IDTokenResponseType);
+            Assert.False(config.IdTokenResponseType);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.Equal("https://oidc.com/issuer", config.Issuer);
             Assert.Equal("OIDC_CLIENT_SECRET", config.ClientSecret);
             Assert.True(config.CodeResponseType);
-            Assert.False(config.IDTokenResponseType);
+            Assert.False(config.IdTokenResponseType);
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.Equal("https://oidc.com/issuer", config.Issuer);
             Assert.Equal("OIDC_CLIENT_SECRET", config.ClientSecret);
             Assert.True(config.CodeResponseType);
-            Assert.False(config.IDTokenResponseType);
+            Assert.False(config.IdTokenResponseType);
         }
 
         [Fact]
@@ -108,7 +108,7 @@ namespace FirebaseAdmin.IntegrationTests.Auth
                 Issuer = "https://oidc.com/updated-issuer",
                 ClientSecret = "UPDATED_OIDC_CLIENT_SECRET",
                 CodeResponseType = false,
-                IDTokenResponseType = true,
+                IdTokenResponseType = true,
             };
 
             var config = await this.auth.UpdateProviderConfigAsync(args);
@@ -120,7 +120,7 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             Assert.Equal("https://oidc.com/updated-issuer", config.Issuer);
             Assert.Equal("UPDATED_OIDC_CLIENT_SECRET", config.ClientSecret);
             Assert.False(config.CodeResponseType);
-            Assert.True(config.IDTokenResponseType);
+            Assert.True(config.IdTokenResponseType);
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/OidcProviderConfigFixture.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/OidcProviderConfigFixture.cs
@@ -33,7 +33,7 @@ namespace FirebaseAdmin.IntegrationTests.Auth
                 Issuer = "https://oidc.com/issuer",
                 ClientSecret = "OIDC_CLIENT_SECRET",
                 CodeResponseType = true,
-                IDTokenResponseType = false,
+                IdTokenResponseType = false,
             };
             this.ProviderConfig = this.Auth.CreateProviderConfigAsync(args).Result;
         }

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/OidcProviderConfigFixture.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/OidcProviderConfigFixture.cs
@@ -31,6 +31,9 @@ namespace FirebaseAdmin.IntegrationTests.Auth
                 Enabled = true,
                 ClientId = "OIDC_CLIENT_ID",
                 Issuer = "https://oidc.com/issuer",
+                ClientSecret = "OIDC_CLIENT_SECRET",
+                CodeResponseType = true,
+                IDTokenResponseType = false,
             };
             this.ProviderConfig = this.Auth.CreateProviderConfigAsync(args).Result;
         }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -711,7 +711,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         Issuer = "https://oidc.com/issuer",
                         CodeResponseType = true,
                     },
-                    "Client secret must not be null or empty for 'code' response type.",
+                    "Client secret must not be null or empty for code response type.",
                 };
                 yield return new object[]
                 {
@@ -805,7 +805,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         Issuer = "https://oidc.com/issuer",
                         CodeResponseType = true,
                     },
-                    "Client secret must not be null or empty for 'code' response type.",
+                    "Client secret must not be null or empty for code response type.",
                 };
                 yield return new object[]
                 {

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -805,7 +805,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         Issuer = "https://oidc.com/issuer",
                         CodeResponseType = true,
                     },
-                    "Client Secret must not be null or empty for code response type",
+                    "Client secret must not be null or empty for 'code' response type.",
                 };
                 yield return new object[]
                 {

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -711,7 +711,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         Issuer = "https://oidc.com/issuer",
                         CodeResponseType = true,
                     },
-                    "Client Secret must not be null or empty for code response type",
+                    "Client secret must not be null or empty for 'code' response type.",
                 };
                 yield return new object[]
                 {

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -639,8 +639,8 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             Assert.Equal("CLIENT_ID", provider.ClientId);
             Assert.Equal("https://oidc.com/issuer", provider.Issuer);
             Assert.Equal("CLIENT_SECRET", provider.ClientSecret);
-            Assert.True(provider.ResponseType.Code);
-            Assert.True(provider.ResponseType.IDToken);
+            Assert.True(provider.CodeResponseType);
+            Assert.True(provider.IDTokenResponseType);
         }
 
         public class InvalidCreateArgs : IEnumerable<object[]>
@@ -794,6 +794,17 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         CodeResponseType = true,
                     },
                     "Client Secret must not be null or empty for code response type",
+                };
+                yield return new object[]
+                {
+                    new OidcProviderConfigArgs()
+                    {
+                        ProviderId = "oidc.provider",
+                        Issuer = "https://oidc.com/issuer",
+                        CodeResponseType = false,
+                        IDTokenResponseType = false,
+                    },
+                    "At least one response type must be returned.",
                 };
             }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -142,7 +142,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                 Issuer = "https://oidc.com/issuer",
                 ClientSecret = "CLIENT_SECRET",
                 CodeResponseType = true,
-                IDTokenResponseType = true,
+                IdTokenResponseType = true,
             };
 
             var provider = await auth.CreateProviderConfigAsync(args);
@@ -265,7 +265,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                 Issuer = "https://oidc.com/issuer",
                 ClientSecret = "CLIENT_SECRET",
                 CodeResponseType = true,
-                IDTokenResponseType = true,
+                IdTokenResponseType = true,
             };
 
             var provider = await auth.UpdateProviderConfigAsync(args);
@@ -640,7 +640,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             Assert.Equal("https://oidc.com/issuer", provider.Issuer);
             Assert.Equal("CLIENT_SECRET", provider.ClientSecret);
             Assert.True(provider.CodeResponseType);
-            Assert.True(provider.IDTokenResponseType);
+            Assert.True(provider.IdTokenResponseType);
         }
 
         public class InvalidCreateArgs : IEnumerable<object[]>
@@ -712,6 +712,18 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         CodeResponseType = true,
                     },
                     "Client Secret must not be null or empty for code response type",
+                };
+                yield return new object[]
+                {
+                    new OidcProviderConfigArgs()
+                    {
+                        ProviderId = "oidc.provider",
+                        ClientId = "CLIENT_ID",
+                        Issuer = "https://oidc.com/issuer",
+                        CodeResponseType = false,
+                        IdTokenResponseType = false,
+                    },
+                    "At least one response type must be returned.",
                 };
             }
 
@@ -802,7 +814,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         ProviderId = "oidc.provider",
                         Issuer = "https://oidc.com/issuer",
                         CodeResponseType = false,
-                        IDTokenResponseType = false,
+                        IdTokenResponseType = false,
                     },
                     "At least one response type must be returned.",
                 };

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -795,7 +795,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         ProviderId = "oidc.provider",
                         Issuer = "not a url",
                     },
-                    "Malformed issuer string: not a url",
+                    "Malformed issuer string: not a URL.",
                 };
                 yield return new object[]
                 {

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -700,7 +700,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         ClientId = "CLIENT_ID",
                         Issuer = "not a url",
                     },
-                    "Malformed issuer string: not a URL.",
+                    "Malformed issuer string: not a url",
                 };
                 yield return new object[]
                 {
@@ -795,7 +795,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         ProviderId = "oidc.provider",
                         Issuer = "not a url",
                     },
-                    "Malformed issuer string: not a URL.",
+                    "Malformed issuer string: not a url",
                 };
                 yield return new object[]
                 {

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -700,7 +700,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
                         ClientId = "CLIENT_ID",
                         Issuer = "not a url",
                     },
-                    "Malformed issuer string: not a url",
+                    "Malformed issuer string: not a URL.",
                 };
                 yield return new object[]
                 {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfig.cs
@@ -28,7 +28,7 @@ namespace FirebaseAdmin.Auth.Providers
             this.ClientId = request.ClientId;
             this.Issuer = request.Issuer;
             this.ClientSecret = request.ClientSecret;
-            this.IDTokenResponseType = request.ResponseType.IDToken == true;
+            this.IdTokenResponseType = request.ResponseType.IdToken == true;
             this.CodeResponseType = request.ResponseType.Code == true;
         }
 
@@ -74,7 +74,7 @@ namespace FirebaseAdmin.Auth.Providers
         /// <summary>
         /// Gets a value indicating whether an ID Token response type will be provided.
         /// </summary>
-        public bool IDTokenResponseType { get; }
+        public bool IdTokenResponseType { get; }
 
         /// <summary>
         /// Gets a value indicating whether an Code type response type will be provided.
@@ -87,7 +87,7 @@ namespace FirebaseAdmin.Auth.Providers
             internal bool? Code { get; set; }
 
             [JsonProperty("idToken")]
-            internal bool? IDToken { get; set; }
+            internal bool? IdToken { get; set; }
         }
 
         internal sealed new class Request : AuthProviderConfig.Request

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfig.cs
@@ -67,7 +67,7 @@ namespace FirebaseAdmin.Auth.Providers
         public string Issuer { get; }
 
         /// <summary>
-        /// Gets the Client Secret used to verify code based response types.
+        /// Gets the client secret, which is used to verify Code response types.
         /// </summary>
         public string ClientSecret { get; }
 

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfig.cs
@@ -28,7 +28,8 @@ namespace FirebaseAdmin.Auth.Providers
             this.ClientId = request.ClientId;
             this.Issuer = request.Issuer;
             this.ClientSecret = request.ClientSecret;
-            this.ResponseType = new ResponseTypeArgs(request.ResponseType);
+            this.IDTokenResponseType = request.ResponseType.IDToken == true;
+            this.CodeResponseType = request.ResponseType.Code == true;
         }
 
         /// <summary>
@@ -71,33 +72,16 @@ namespace FirebaseAdmin.Auth.Providers
         public string ClientSecret { get; }
 
         /// <summary>
-        /// Gets what response types are being used for this OIDC config.
+        /// Gets a value indicating whether an ID Token response type will be provided.
         /// </summary>
-        public ResponseTypeArgs ResponseType { get; }
+        public bool IDTokenResponseType { get; }
 
         /// <summary>
-        /// Represents the response types beinf used for this OIDC config.
+        /// Gets a value indicating whether an Code type response type will be provided.
         /// </summary>
-        public class ResponseTypeArgs
-        {
-            internal ResponseTypeArgs(ResponseTypeJson request)
-            {
-                this.Code = request.Code;
-                this.IDToken = request.IDToken;
-            }
+        public bool CodeResponseType { get; }
 
-            /// <summary>
-            /// Gets a value indicating whether this OIDC provider uses a code based response type.
-            /// </summary>
-            public bool? Code { get; }
-
-            /// <summary>
-            /// Gets a value indicating whether this OIDC provider uses an ID-token based response type.
-            /// </summary>
-            public bool? IDToken { get; }
-        }
-
-        internal sealed class ResponseTypeJson
+        internal sealed class ResponseTypeInfo
         {
             [JsonProperty("code")]
             internal bool? Code { get; set; }
@@ -118,7 +102,7 @@ namespace FirebaseAdmin.Auth.Providers
             internal string ClientSecret { get; set; }
 
             [JsonProperty("responseType")]
-            internal ResponseTypeJson ResponseType { get; set; }
+            internal ResponseTypeInfo ResponseType { get; set; }
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfig.cs
@@ -27,6 +27,8 @@ namespace FirebaseAdmin.Auth.Providers
         {
             this.ClientId = request.ClientId;
             this.Issuer = request.Issuer;
+            this.ClientSecret = request.ClientSecret;
+            this.ResponseType = new ResponseTypeArgs(request.ResponseType);
         }
 
         /// <summary>
@@ -63,6 +65,47 @@ namespace FirebaseAdmin.Auth.Providers
         /// </summary>
         public string Issuer { get; }
 
+        /// <summary>
+        /// Gets the Client Secret used to verify code based response types.
+        /// </summary>
+        public string ClientSecret { get; }
+
+        /// <summary>
+        /// Gets what response types are being used for this OIDC config.
+        /// </summary>
+        public ResponseTypeArgs ResponseType { get; }
+
+        /// <summary>
+        /// Represents the response types beinf used for this OIDC config.
+        /// </summary>
+        public class ResponseTypeArgs
+        {
+            internal ResponseTypeArgs(ResponseTypeJson request)
+            {
+                this.Code = request.Code;
+                this.IDToken = request.IDToken;
+            }
+
+            /// <summary>
+            /// Gets a value indicating whether this OIDC provider uses a code based response type.
+            /// </summary>
+            public bool? Code { get; }
+
+            /// <summary>
+            /// Gets a value indicating whether this OIDC provider uses an ID-token based response type.
+            /// </summary>
+            public bool? IDToken { get; }
+        }
+
+        internal sealed class ResponseTypeJson
+        {
+            [JsonProperty("code")]
+            internal bool? Code { get; set; }
+
+            [JsonProperty("idToken")]
+            internal bool? IDToken { get; set; }
+        }
+
         internal sealed new class Request : AuthProviderConfig.Request
         {
             [JsonProperty("clientId")]
@@ -70,6 +113,12 @@ namespace FirebaseAdmin.Auth.Providers
 
             [JsonProperty("issuer")]
             internal string Issuer { get; set; }
+
+            [JsonProperty("clientSecret")]
+            internal string ClientSecret { get; set; }
+
+            [JsonProperty("responseType")]
+            internal ResponseTypeJson ResponseType { get; set; }
         }
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
@@ -57,7 +57,7 @@ namespace FirebaseAdmin.Auth.Providers
         public string Issuer { get; set; }
 
         /// <summary>
-        /// Gets or sets the Client Secret used to verify code based response types.
+        /// Gets or sets the client secret, which is used to verify Code response types.
         /// </summary>
         public string ClientSecret { get; set; }
 

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
@@ -83,7 +83,7 @@ namespace FirebaseAdmin.Auth.Providers
             };
             if (this.CodeResponseType != null || this.IDTokenResponseType != null)
             {
-                req.ResponseType = new OidcProviderConfig.ResponseTypeJson()
+                req.ResponseType = new OidcProviderConfig.ResponseTypeInfo()
                 {
                     Code = this.CodeResponseType,
                     IDToken = this.IDTokenResponseType,
@@ -124,7 +124,7 @@ namespace FirebaseAdmin.Auth.Providers
             };
             if (this.CodeResponseType != null || this.IDTokenResponseType != null)
             {
-                req.ResponseType = new OidcProviderConfig.ResponseTypeJson()
+                req.ResponseType = new OidcProviderConfig.ResponseTypeInfo()
                 {
                     Code = this.CodeResponseType,
                     IDToken = this.IDTokenResponseType,
@@ -148,6 +148,11 @@ namespace FirebaseAdmin.Auth.Providers
             if (req.ResponseType?.Code == true && string.IsNullOrEmpty(req.ClientSecret))
             {
                 throw new ArgumentException("Client Secret must not be null or empty for code response type");
+            }
+
+            if (req.ResponseType?.Code == false && req.ResponseType?.IDToken == false)
+            {
+                throw new ArgumentException("At least one response type must be returned.");
             }
 
             return req;

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
@@ -106,7 +106,7 @@ namespace FirebaseAdmin.Auth.Providers
 
             if (req.ResponseType?.Code == true && string.IsNullOrEmpty(req.ClientSecret))
             {
-                throw new ArgumentException("Client Secret must not be null or empty for code response type");
+                throw new ArgumentException("Client secret must not be null or empty for code response type.");
             }
 
             if (req.ResponseType?.Code == false && req.ResponseType?.IdToken == false)

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
@@ -64,7 +64,7 @@ namespace FirebaseAdmin.Auth.Providers
         /// <summary>
         /// Gets or sets a value indicating whether this OIDC provider uses an ID-token based response type.
         /// </summary>
-        public bool? IDTokenResponseType { get; set; }
+        public bool? IdTokenResponseType { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether this OIDC provider uses a code based response type.
@@ -81,12 +81,12 @@ namespace FirebaseAdmin.Auth.Providers
                 Issuer = this.Issuer,
                 ClientSecret = this.ClientSecret,
             };
-            if (this.CodeResponseType != null || this.IDTokenResponseType != null)
+            if (this.CodeResponseType != null || this.IdTokenResponseType != null)
             {
                 req.ResponseType = new OidcProviderConfig.ResponseTypeInfo()
                 {
                     Code = this.CodeResponseType,
-                    IDToken = this.IDTokenResponseType,
+                    IdToken = this.IdTokenResponseType,
                 };
             }
 
@@ -109,6 +109,11 @@ namespace FirebaseAdmin.Auth.Providers
                 throw new ArgumentException("Client Secret must not be null or empty for code response type");
             }
 
+            if (req.ResponseType?.Code == false && req.ResponseType?.IdToken == false)
+            {
+                throw new ArgumentException("At least one response type must be returned.");
+            }
+
             return req;
         }
 
@@ -122,12 +127,12 @@ namespace FirebaseAdmin.Auth.Providers
                 Issuer = this.Issuer,
                 ClientSecret = this.ClientSecret,
             };
-            if (this.CodeResponseType != null || this.IDTokenResponseType != null)
+            if (this.CodeResponseType != null || this.IdTokenResponseType != null)
             {
                 req.ResponseType = new OidcProviderConfig.ResponseTypeInfo()
                 {
                     Code = this.CodeResponseType,
-                    IDToken = this.IDTokenResponseType,
+                    IdToken = this.IdTokenResponseType,
                 };
             }
 
@@ -150,7 +155,7 @@ namespace FirebaseAdmin.Auth.Providers
                 throw new ArgumentException("Client Secret must not be null or empty for code response type");
             }
 
-            if (req.ResponseType?.Code == false && req.ResponseType?.IDToken == false)
+            if (req.ResponseType?.Code == false && req.ResponseType?.IdToken == false)
             {
                 throw new ArgumentException("At least one response type must be returned.");
             }

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
@@ -62,7 +62,7 @@ namespace FirebaseAdmin.Auth.Providers
         public string ClientSecret { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this OIDC provider uses an ID-token based response type.
+        /// Gets or sets a value indicating whether this OIDC provider uses an ID Token response type.
         /// </summary>
         public bool? IdTokenResponseType { get; set; }
 

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
@@ -67,7 +67,7 @@ namespace FirebaseAdmin.Auth.Providers
         public bool? IdTokenResponseType { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this OIDC provider uses a code based response type.
+        /// Gets or sets a value indicating whether this OIDC provider uses a Code response type.
         /// </summary>
         public bool? CodeResponseType { get; set; }
 

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
@@ -56,6 +56,21 @@ namespace FirebaseAdmin.Auth.Providers
         /// </summary>
         public string Issuer { get; set; }
 
+        /// <summary>
+        /// Gets or sets the Client Secret used to verify code based response types.
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this OIDC provider uses an ID-token based response type.
+        /// </summary>
+        public bool? IDTokenResponseType { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this OIDC provider uses a code based response type.
+        /// </summary>
+        public bool? CodeResponseType { get; set; }
+
         internal override AuthProviderConfig.Request ToCreateRequest()
         {
             var req = new OidcProviderConfig.Request()
@@ -64,7 +79,17 @@ namespace FirebaseAdmin.Auth.Providers
                 Enabled = this.Enabled,
                 ClientId = this.ClientId,
                 Issuer = this.Issuer,
+                ClientSecret = this.ClientSecret,
             };
+            if (this.CodeResponseType != null || this.IDTokenResponseType != null)
+            {
+                req.ResponseType = new OidcProviderConfig.ResponseTypeJson()
+                {
+                    Code = this.CodeResponseType,
+                    IDToken = this.IDTokenResponseType,
+                };
+            }
+
             if (string.IsNullOrEmpty(req.ClientId))
             {
                 throw new ArgumentException("Client ID must not be null or empty.");
@@ -79,6 +104,11 @@ namespace FirebaseAdmin.Auth.Providers
                 throw new ArgumentException($"Malformed issuer string: {req.Issuer}");
             }
 
+            if (req.ResponseType?.Code == true && string.IsNullOrEmpty(req.ClientSecret))
+            {
+                throw new ArgumentException("Client Secret must not be null or empty for code response type");
+            }
+
             return req;
         }
 
@@ -90,7 +120,16 @@ namespace FirebaseAdmin.Auth.Providers
                 Enabled = this.Enabled,
                 ClientId = this.ClientId,
                 Issuer = this.Issuer,
+                ClientSecret = this.ClientSecret,
             };
+            if (this.CodeResponseType != null || this.IDTokenResponseType != null)
+            {
+                req.ResponseType = new OidcProviderConfig.ResponseTypeJson()
+                {
+                    Code = this.CodeResponseType,
+                    IDToken = this.IDTokenResponseType,
+                };
+            }
 
             if (req.ClientId == string.Empty)
             {
@@ -104,6 +143,11 @@ namespace FirebaseAdmin.Auth.Providers
             else if (req.Issuer != null && !IsWellFormedUriString(req.Issuer))
             {
                 throw new ArgumentException($"Malformed issuer string: {req.Issuer}");
+            }
+
+            if (req.ResponseType?.Code == true && string.IsNullOrEmpty(req.ClientSecret))
+            {
+                throw new ArgumentException("Client Secret must not be null or empty for code response type");
             }
 
             return req;

--- a/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/Providers/OidcProviderConfigArgs.cs
@@ -152,7 +152,7 @@ namespace FirebaseAdmin.Auth.Providers
 
             if (req.ResponseType?.Code == true && string.IsNullOrEmpty(req.ClientSecret))
             {
-                throw new ArgumentException("Client Secret must not be null or empty for code response type");
+                throw new ArgumentException("Client secret must not be null or empty for code response type.");
             }
 
             if (req.ResponseType?.Code == false && req.ResponseType?.IdToken == false)


### PR DESCRIPTION
Provides an option for developers to specify the OAuth response type for their OIDC provider (either one of these can be set:):

- id_token
- code (if set, must also set the client secret)