### PR TITLE
Android notification EventTime property

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -274,6 +274,7 @@ namespace FirebaseAdmin.Messaging.Tests
                         BodyLocKey = "body-loc-key",
                         BodyLocArgs = new List<string>() { "arg3", "arg4" },
                         ChannelId = "channel-id",
+                        EventTime = new DateTime(1998, 9, 4, 0, 0, 0, DateTimeKind.Utc),
                     },
                     FcmOptions = new AndroidFcmOptions()
                     {
@@ -308,6 +309,7 @@ namespace FirebaseAdmin.Messaging.Tests
                                 { "body_loc_key", "body-loc-key" },
                                 { "body_loc_args", new JArray() { "arg3", "arg4" } },
                                 { "channel_id", "channel-id" },
+                                { "event_time", new DateTime(1998, 9, 4, 0, 0, 0, DateTimeKind.Utc) },
                             }
                         },
                         {

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
@@ -119,6 +119,14 @@ namespace FirebaseAdmin.Messaging
         public string ChannelId { get; set; }
 
         /// <summary>
+        /// Gets or sets the time that the event in the notification occurred for notifications that
+        /// inform users about events with an absolute time reference. Notifications in the panel are
+        /// sorted by this time.
+        /// </summary>
+        [JsonProperty("event_time")]
+        public DateTime EventTime { get; set; }
+
+        /// <summary>
         /// Copies this notification, and validates the content of it to ensure that it can be
         /// serialized into the JSON format expected by the FCM service.
         /// </summary>
@@ -139,6 +147,7 @@ namespace FirebaseAdmin.Messaging
                 BodyLocKey = this.BodyLocKey,
                 BodyLocArgs = this.BodyLocArgs?.ToList(),
                 ChannelId = this.ChannelId,
+                EventTime = this.EventTime,
             };
             if (copy.Color != null && !Regex.Match(copy.Color, "^#[0-9a-fA-F]{6}$").Success)
             {

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidNotification.cs
@@ -124,7 +124,7 @@ namespace FirebaseAdmin.Messaging
         /// sorted by this time.
         /// </summary>
         [JsonProperty("event_time")]
-        public DateTime EventTime { get; set; }
+        public DateTime? EventTime { get; set; }
 
         /// <summary>
         /// Copies this notification, and validates the content of it to ensure that it can be


### PR DESCRIPTION
Added the `EventTime` property to `AndroidNotification` so it can be set. 

This is basically the equivalent of this code in Java:
```java
androidBuilder.setEventTimeInMillis(SomeValue);
```

I also took the [documentation of the Java-side](https://github.com/firebase/firebase-admin-java/blob/master/src/main/java/com/google/firebase/messaging/AndroidNotification.java#L448-L458) and changed it a bit to comply with the code style of this project.

Tested on my local machine with sending notifications and it works like a charm 😄 