### PR TITLE
chore: Build .net framework targets on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,12 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
 
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_NOLOGO: 1
 
     runs-on: ${{ matrix.os }}
 
@@ -18,16 +19,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v1
 
-    - name: Setup .NET Core
+    - name: Setup .NET Core 2.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.2.108
+        dotnet-version: 2.1.x
 
     - name: Build with dotnet
       run: |
-        dotnet build FirebaseAdmin/FirebaseAdmin
-        dotnet build FirebaseAdmin/FirebaseAdmin.Snippets
-        dotnet build FirebaseAdmin/FirebaseAdmin.IntegrationTests
+        dotnet msbuild FirebaseAdmin/FirebaseAdmin
+        dotnet msbuild FirebaseAdmin/FirebaseAdmin.Snippets
+        dotnet msbuild FirebaseAdmin/FirebaseAdmin.IntegrationTests
 
     - name: Run unit tests
       run: dotnet test FirebaseAdmin/FirebaseAdmin.Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       with:
         dotnet-version: 2.1.x
 
+    - name: Install dependencies
+      run: dotnet msbuild /t:restore FirebaseAdmin
+
     - name: Build with dotnet
       run: |
         dotnet msbuild FirebaseAdmin/FirebaseAdmin

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,7 @@ jobs:
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_NOLOGO: 1
 
     steps:
     - name: Checkout source for staging
@@ -43,7 +44,7 @@ jobs:
         dotnet-version: 2.1.x
 
     - name: Build with dotnet
-      run: dotnet build FirebaseAdmin/FirebaseAdmin
+      run: dotnet msbuild FirebaseAdmin/FirebaseAdmin
 
     - name: Run unit tests
       run: dotnet test FirebaseAdmin/FirebaseAdmin.Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,9 @@ jobs:
       with:
         dotnet-version: 2.1.x
 
+    - name: Install dependencies
+      run: dotnet msbuild /t:restore FirebaseAdmin
+
     - name: Build with dotnet
       run: dotnet msbuild FirebaseAdmin/FirebaseAdmin
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,12 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'release:publish'))
 
     # Build and package artifacts on Windows.
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_NOLOGO: 1
 
     # When manually triggering the build, the requester can specify a target branch or a tag
     # via the 'ref' client parameter.
@@ -49,14 +50,19 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
+    - name: Setup .NET Core 2.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 2.1.x
+
     - name: Build with dotnet
-      run: dotnet build FirebaseAdmin/FirebaseAdmin
+      run: dotnet msbuild FirebaseAdmin/FirebaseAdmin
 
     - name: Run unit tests
       run: dotnet test FirebaseAdmin/FirebaseAdmin.Tests
 
     - name: Run integration tests
-      run: ./.github/scripts/run_integration_tests
+      run: ./.github/scripts/run_integration_tests.sh
       env:
         FIREBASE_SERVICE_ACCT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCT_KEY }}
         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
       with:
         dotnet-version: 2.1.x
 
+    - name: Install dependencies
+      run: dotnet msbuild /t:restore FirebaseAdmin
+
     - name: Build with dotnet
       run: dotnet msbuild FirebaseAdmin/FirebaseAdmin
 

--- a/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <Version>2.2.0</Version>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>
@@ -25,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Google.Api.Gax.Rest" Version="3.2.0" />
     <PackageReference Include="Google.Apis.Auth" Version="1.49.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />


### PR DESCRIPTION
- Github Actions images no longer support .net framework 4.6, breaking CI tests and the release process.
- Updated workflow files to build Nuget package [targeting the .net framework](https://github.com/Microsoft/dotnet/tree/master/releases/reference-assemblies) on ubuntu-latest.