### PR TITLE
Add interfaces for FirebaseMessaging to use DI and mocking in the real projects

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
@@ -72,98 +72,28 @@ namespace FirebaseAdmin.Messaging
             });
         }
 
-        /// <summary>
-        /// Sends a message to the FCM service for delivery. The message gets validated both by
-        /// the Admin SDK, and the remote FCM service. A successful return value indicates
-        /// that the message has been successfully sent to FCM, where it has been accepted by the
-        /// FCM service.
-        /// </summary>
-        /// <returns>A task that completes with a message ID string, which represents
-        /// successful handoff to FCM.</returns>
-        /// <exception cref="ArgumentNullException">If the message argument is null.</exception>
-        /// <exception cref="ArgumentException">If the message contains any invalid
-        /// fields.</exception>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// message.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
+        /// <inheritdoc />
         public async Task<string> SendAsync(Message message)
         {
             return await this.SendAsync(message, false)
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends a message to the FCM service for delivery. The message gets validated both by
-        /// the Admin SDK, and the remote FCM service. A successful return value indicates
-        /// that the message has been successfully sent to FCM, where it has been accepted by the
-        /// FCM service.
-        /// </summary>
-        /// <returns>A task that completes with a message ID string, which represents
-        /// successful handoff to FCM.</returns>
-        /// <exception cref="ArgumentNullException">If the message argument is null.</exception>
-        /// <exception cref="ArgumentException">If the message contains any invalid
-        /// fields.</exception>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// message.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
+        /// <inheritdoc />
         public async Task<string> SendAsync(Message message, CancellationToken cancellationToken)
         {
             return await this.SendAsync(message, false, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends a message to the FCM service for delivery. The message gets validated both by
-        /// the Admin SDK, and the remote FCM service. A successful return value indicates
-        /// that the message has been successfully sent to FCM, where it has been accepted by the
-        /// FCM service.
-        /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
-        /// actually sent to the recipients. Instead, the FCM service performs all the necessary
-        /// validations, and emulates the send operation. This is a good way to check if a
-        /// certain message will be accepted by FCM for delivery.</para>
-        /// </summary>
-        /// <returns>A task that completes with a message ID string, which represents
-        /// successful handoff to FCM.</returns>
-        /// <exception cref="ArgumentNullException">If the message argument is null.</exception>
-        /// <exception cref="ArgumentException">If the message contains any invalid
-        /// fields.</exception>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// message.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
-        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
-        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
-        /// but it will not be delivered to any actual recipients.</param>
+        /// <inheritdoc />
         public async Task<string> SendAsync(Message message, bool dryRun)
         {
             return await this.SendAsync(message, dryRun, default(CancellationToken))
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends a message to the FCM service for delivery. The message gets validated both by
-        /// the Admin SDK, and the remote FCM service. A successful return value indicates
-        /// that the message has been successfully sent to FCM, where it has been accepted by the
-        /// FCM service.
-        /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
-        /// actually sent to the recipients. Instead, the FCM service performs all the necessary
-        /// validations, and emulates the send operation. This is a good way to check if a
-        /// certain message will be accepted by FCM for delivery.</para>
-        /// </summary>
-        /// <returns>A task that completes with a message ID string, which represents
-        /// successful handoff to FCM.</returns>
-        /// <exception cref="ArgumentNullException">If the message argument is null.</exception>
-        /// <exception cref="ArgumentException">If the message contains any invalid
-        /// fields.</exception>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// message.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
-        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
-        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
-        /// but it will not be delivered to any actual recipients.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
+        /// <inheritdoc />
         public async Task<string> SendAsync(
             Message message, bool dryRun, CancellationToken cancellationToken)
         {
@@ -171,148 +101,56 @@ namespace FirebaseAdmin.Messaging
                 message, dryRun, cancellationToken).ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends all the messages in the given list via Firebase Cloud Messaging. Employs batching to
-        /// send the entire list as a single RPC call. Compared to the <see cref="SendAsync(Message)"/>
-        /// method, this is a significantly more efficient way to send multiple messages.
-        /// </summary>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// messages.</exception>
-        /// <param name="messages">Up to 100 messages to send in the batch. Cannot be null.</param>
-        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
-        /// outcome.</returns>
+        /// <inheritdoc />
         public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages)
         {
             return await this.SendAllAsync(messages, false)
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends all the messages in the given list via Firebase Cloud Messaging. Employs batching to
-        /// send the entire list as a single RPC call. Compared to the <see cref="SendAsync(Message)"/>
-        /// method, this is a significantly more efficient way to send multiple messages.
-        /// </summary>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// messages.</exception>
-        /// <param name="messages">Up to 100 messages to send in the batch. Cannot be null.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
-        /// outcome.</returns>
+        /// <inheritdoc />
         public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)
         {
             return await this.SendAllAsync(messages, false, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends all the messages in the given list via Firebase Cloud Messaging. Employs batching to
-        /// send the entire list as a single RPC call. Compared to the <see cref="SendAsync(Message)"/>
-        /// method, this is a significantly more efficient way to send multiple messages.
-        /// </summary>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// messages.</exception>
-        /// <param name="messages">Up to 100 messages to send in the batch. Cannot be null.</param>
-        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
-        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
-        /// but it will not be delivered to any actual recipients.</param>
-        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
-        /// outcome.</returns>
+        /// <inheritdoc />
         public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, bool dryRun)
         {
             return await this.SendAllAsync(messages, dryRun, default)
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends all the messages in the given list via Firebase Cloud Messaging. Employs batching to
-        /// send the entire list as a single RPC call. Compared to the <see cref="SendAsync(Message)"/>
-        /// method, this is a significantly more efficient way to send multiple messages.
-        /// </summary>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// messages.</exception>
-        /// <param name="messages">Up to 100 messages to send in the batch. Cannot be null.</param>
-        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
-        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
-        /// but it will not be delivered to any actual recipients.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
-        /// outcome.</returns>
+        /// <inheritdoc />
         public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, bool dryRun, CancellationToken cancellationToken)
         {
             return await this.messagingClient.SendAllAsync(messages, dryRun, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
-        /// </summary>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// messages.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
-        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
-        /// outcome.</returns>
+        /// <inheritdoc />
         public async Task<BatchResponse> SendMulticastAsync(MulticastMessage message)
         {
             return await this.SendMulticastAsync(message, false)
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
-        /// </summary>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// messages.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
-        /// outcome.</returns>
+        /// <inheritdoc />
         public async Task<BatchResponse> SendMulticastAsync(MulticastMessage message, CancellationToken cancellationToken)
         {
             return await this.SendMulticastAsync(message, false, cancellationToken)
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
-        /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
-        /// actually sent to the recipients. Instead, the FCM service performs all the necessary
-        /// validations, and emulates the send operation. This is a good way to check if a
-        /// certain message will be accepted by FCM for delivery.</para>
-        /// </summary>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// messages.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
-        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
-        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
-        /// but it will not be delivered to any actual recipients.</param>
-        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
-        /// outcome.</returns>
+        /// <inheritdoc />
         public async Task<BatchResponse> SendMulticastAsync(MulticastMessage message, bool dryRun)
         {
             return await this.SendMulticastAsync(message, dryRun, default)
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
-        /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
-        /// actually sent to the recipients. Instead, the FCM service performs all the necessary
-        /// validations, and emulates the send operation. This is a good way to check if a
-        /// certain message will be accepted by FCM for delivery.</para>
-        /// </summary>
-        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
-        /// messages.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
-        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
-        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
-        /// but it will not be delivered to any actual recipients.</param>
-        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
-        /// operation.</param>
-        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
-        /// outcome.</returns>
+        /// <inheritdoc />
         public async Task<BatchResponse> SendMulticastAsync(
             MulticastMessage message, bool dryRun, CancellationToken cancellationToken)
         {
@@ -321,12 +159,7 @@ namespace FirebaseAdmin.Messaging
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Subscribes a list of registration tokens to a topic.
-        /// </summary>
-        /// <param name="registrationTokens">A list of registration tokens to subscribe.</param>
-        /// <param name="topic">The topic name to subscribe to. /topics/ will be prepended to the topic name provided if absent.</param>
-        /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving details about the topic subscription operations.</returns>
+        /// <inheritdoc />
         public async Task<TopicManagementResponse> SubscribeToTopicAsync(
             IReadOnlyList<string> registrationTokens, string topic)
         {
@@ -334,12 +167,7 @@ namespace FirebaseAdmin.Messaging
                 .ConfigureAwait(false);
         }
 
-        /// <summary>
-        /// Unsubscribes a list of registration tokens from a topic.
-        /// </summary>
-        /// <param name="registrationTokens">A list of registration tokens to unsubscribe.</param>
-        /// <param name="topic">The topic name to unsubscribe from. /topics/ will be prepended to the topic name provided if absent.</param>
-        /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving details about the topic unsubscription operations.</returns>
+        /// <inheritdoc />
         public async Task<TopicManagementResponse> UnsubscribeFromTopicAsync(
             IReadOnlyList<string> registrationTokens, string topic)
         {

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/IFirebaseMessageSender.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/IFirebaseMessageSender.cs
@@ -1,4 +1,4 @@
-// Copyright 2018, Google Inc. All rights reserved.
+// Copyright 2022, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,58 +20,10 @@ using System.Threading.Tasks;
 namespace FirebaseAdmin.Messaging
 {
     /// <summary>
-    /// This is the entry point to all server-side Firebase Cloud Messaging (FCM) operations. You
-    /// can get an instance of this class via <c>FirebaseMessaging.DefaultInstance</c>.
+    /// Service to send messages to the FCM service for delivery.
     /// </summary>
-    public sealed class FirebaseMessaging : IFirebaseService, IFirebaseMessageSender, IFirebaseMessageSubscriber
+    public interface IFirebaseMessageSender
     {
-        private readonly FirebaseMessagingClient messagingClient;
-        private readonly InstanceIdClient instanceIdClient;
-
-        private FirebaseMessaging(FirebaseApp app)
-        {
-            this.messagingClient = FirebaseMessagingClient.Create(app);
-            this.instanceIdClient = InstanceIdClient.Create(app);
-        }
-
-        /// <summary>
-        /// Gets the messaging instance associated with the default Firebase app. This property is
-        /// <c>null</c> if the default app doesn't yet exist.
-        /// </summary>
-        public static FirebaseMessaging DefaultInstance
-        {
-            get
-            {
-                var app = FirebaseApp.DefaultInstance;
-                if (app == null)
-                {
-                    return null;
-                }
-
-                return GetMessaging(app);
-            }
-        }
-
-        /// <summary>
-        /// Returns the messaging instance for the specified app.
-        /// </summary>
-        /// <returns>The <see cref="FirebaseMessaging"/> instance associated with the specified
-        /// app.</returns>
-        /// <exception cref="System.ArgumentNullException">If the app argument is null.</exception>
-        /// <param name="app">An app instance.</param>
-        public static FirebaseMessaging GetMessaging(FirebaseApp app)
-        {
-            if (app == null)
-            {
-                throw new ArgumentNullException("App argument must not be null.");
-            }
-
-            return app.GetOrInit<FirebaseMessaging>(typeof(FirebaseMessaging).Name, () =>
-            {
-                return new FirebaseMessaging(app);
-            });
-        }
-
         /// <summary>
         /// Sends a message to the FCM service for delivery. The message gets validated both by
         /// the Admin SDK, and the remote FCM service. A successful return value indicates
@@ -86,11 +38,7 @@ namespace FirebaseAdmin.Messaging
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// message.</exception>
         /// <param name="message">The message to be sent. Must not be null.</param>
-        public async Task<string> SendAsync(Message message)
-        {
-            return await this.SendAsync(message, false)
-                .ConfigureAwait(false);
-        }
+        Task<string> SendAsync(Message message);
 
         /// <summary>
         /// Sends a message to the FCM service for delivery. The message gets validated both by
@@ -108,11 +56,7 @@ namespace FirebaseAdmin.Messaging
         /// <param name="message">The message to be sent. Must not be null.</param>
         /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
         /// operation.</param>
-        public async Task<string> SendAsync(Message message, CancellationToken cancellationToken)
-        {
-            return await this.SendAsync(message, false, cancellationToken)
-                .ConfigureAwait(false);
-        }
+        Task<string> SendAsync(Message message, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends a message to the FCM service for delivery. The message gets validated both by
@@ -135,11 +79,7 @@ namespace FirebaseAdmin.Messaging
         /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
         /// only) of the send. If set to true, the message will be sent to the FCM backend service,
         /// but it will not be delivered to any actual recipients.</param>
-        public async Task<string> SendAsync(Message message, bool dryRun)
-        {
-            return await this.SendAsync(message, dryRun, default(CancellationToken))
-                .ConfigureAwait(false);
-        }
+        Task<string> SendAsync(Message message, bool dryRun);
 
         /// <summary>
         /// Sends a message to the FCM service for delivery. The message gets validated both by
@@ -164,16 +104,12 @@ namespace FirebaseAdmin.Messaging
         /// but it will not be delivered to any actual recipients.</param>
         /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
         /// operation.</param>
-        public async Task<string> SendAsync(
-            Message message, bool dryRun, CancellationToken cancellationToken)
-        {
-            return await this.messagingClient.SendAsync(
-                message, dryRun, cancellationToken).ConfigureAwait(false);
-        }
+        Task<string> SendAsync(
+            Message message, bool dryRun, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends all the messages in the given list via Firebase Cloud Messaging. Employs batching to
-        /// send the entire list as a single RPC call. Compared to the <see cref="SendAsync(Message)"/>
+        /// send the entire list as a single RPC call. Compared to the <see cref="FirebaseMessaging.SendAsync(FirebaseAdmin.Messaging.Message)"/>
         /// method, this is a significantly more efficient way to send multiple messages.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
@@ -181,15 +117,11 @@ namespace FirebaseAdmin.Messaging
         /// <param name="messages">Up to 100 messages to send in the batch. Cannot be null.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
-        public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages)
-        {
-            return await this.SendAllAsync(messages, false)
-                .ConfigureAwait(false);
-        }
+        Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages);
 
         /// <summary>
         /// Sends all the messages in the given list via Firebase Cloud Messaging. Employs batching to
-        /// send the entire list as a single RPC call. Compared to the <see cref="SendAsync(Message)"/>
+        /// send the entire list as a single RPC call. Compared to the <see cref="FirebaseMessaging.SendAsync(FirebaseAdmin.Messaging.Message)"/>
         /// method, this is a significantly more efficient way to send multiple messages.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
@@ -199,15 +131,11 @@ namespace FirebaseAdmin.Messaging
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
-        public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)
-        {
-            return await this.SendAllAsync(messages, false, cancellationToken)
-                .ConfigureAwait(false);
-        }
+        Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends all the messages in the given list via Firebase Cloud Messaging. Employs batching to
-        /// send the entire list as a single RPC call. Compared to the <see cref="SendAsync(Message)"/>
+        /// send the entire list as a single RPC call. Compared to the <see cref="FirebaseMessaging.SendAsync(FirebaseAdmin.Messaging.Message)"/>
         /// method, this is a significantly more efficient way to send multiple messages.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
@@ -218,15 +146,11 @@ namespace FirebaseAdmin.Messaging
         /// but it will not be delivered to any actual recipients.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
-        public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, bool dryRun)
-        {
-            return await this.SendAllAsync(messages, dryRun, default)
-                .ConfigureAwait(false);
-        }
+        Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, bool dryRun);
 
         /// <summary>
         /// Sends all the messages in the given list via Firebase Cloud Messaging. Employs batching to
-        /// send the entire list as a single RPC call. Compared to the <see cref="SendAsync(Message)"/>
+        /// send the entire list as a single RPC call. Compared to the <see cref="FirebaseMessaging.SendAsync(FirebaseAdmin.Messaging.Message)"/>
         /// method, this is a significantly more efficient way to send multiple messages.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
@@ -239,11 +163,7 @@ namespace FirebaseAdmin.Messaging
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
-        public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, bool dryRun, CancellationToken cancellationToken)
-        {
-            return await this.messagingClient.SendAllAsync(messages, dryRun, cancellationToken)
-                .ConfigureAwait(false);
-        }
+        Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, bool dryRun, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends the given multicast message to all the FCM registration tokens specified in it.
@@ -253,11 +173,7 @@ namespace FirebaseAdmin.Messaging
         /// <param name="message">The message to be sent. Must not be null.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
-        public async Task<BatchResponse> SendMulticastAsync(MulticastMessage message)
-        {
-            return await this.SendMulticastAsync(message, false)
-                .ConfigureAwait(false);
-        }
+        Task<BatchResponse> SendMulticastAsync(MulticastMessage message);
 
         /// <summary>
         /// Sends the given multicast message to all the FCM registration tokens specified in it.
@@ -269,11 +185,7 @@ namespace FirebaseAdmin.Messaging
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
-        public async Task<BatchResponse> SendMulticastAsync(MulticastMessage message, CancellationToken cancellationToken)
-        {
-            return await this.SendMulticastAsync(message, false, cancellationToken)
-                .ConfigureAwait(false);
-        }
+        Task<BatchResponse> SendMulticastAsync(MulticastMessage message, CancellationToken cancellationToken);
 
         /// <summary>
         /// Sends the given multicast message to all the FCM registration tokens specified in it.
@@ -290,11 +202,7 @@ namespace FirebaseAdmin.Messaging
         /// but it will not be delivered to any actual recipients.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
-        public async Task<BatchResponse> SendMulticastAsync(MulticastMessage message, bool dryRun)
-        {
-            return await this.SendMulticastAsync(message, dryRun, default)
-                .ConfigureAwait(false);
-        }
+        Task<BatchResponse> SendMulticastAsync(MulticastMessage message, bool dryRun);
 
         /// <summary>
         /// Sends the given multicast message to all the FCM registration tokens specified in it.
@@ -313,47 +221,7 @@ namespace FirebaseAdmin.Messaging
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
-        public async Task<BatchResponse> SendMulticastAsync(
-            MulticastMessage message, bool dryRun, CancellationToken cancellationToken)
-        {
-            return await this.SendAllAsync(
-                message.GetMessageList(), dryRun, cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Subscribes a list of registration tokens to a topic.
-        /// </summary>
-        /// <param name="registrationTokens">A list of registration tokens to subscribe.</param>
-        /// <param name="topic">The topic name to subscribe to. /topics/ will be prepended to the topic name provided if absent.</param>
-        /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving details about the topic subscription operations.</returns>
-        public async Task<TopicManagementResponse> SubscribeToTopicAsync(
-            IReadOnlyList<string> registrationTokens, string topic)
-        {
-            return await this.instanceIdClient.SubscribeToTopicAsync(registrationTokens, topic)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Unsubscribes a list of registration tokens from a topic.
-        /// </summary>
-        /// <param name="registrationTokens">A list of registration tokens to unsubscribe.</param>
-        /// <param name="topic">The topic name to unsubscribe from. /topics/ will be prepended to the topic name provided if absent.</param>
-        /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving details about the topic unsubscription operations.</returns>
-        public async Task<TopicManagementResponse> UnsubscribeFromTopicAsync(
-            IReadOnlyList<string> registrationTokens, string topic)
-        {
-            return await this.instanceIdClient.UnsubscribeFromTopicAsync(registrationTokens, topic)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Deletes this <see cref="FirebaseMessaging"/> service instance.
-        /// </summary>
-        void IFirebaseService.Delete()
-        {
-            this.messagingClient.Dispose();
-            this.instanceIdClient.Dispose();
-        }
+        Task<BatchResponse> SendMulticastAsync(
+            MulticastMessage message, bool dryRun, CancellationToken cancellationToken);
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/IFirebaseMessageSubscriber.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/IFirebaseMessageSubscriber.cs
@@ -1,0 +1,43 @@
+// Copyright 2022, Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace FirebaseAdmin.Messaging
+{
+    /// <summary>
+    /// Service to subscribe or unsubscribe registration tokens to a topic.
+    /// </summary>
+    public interface IFirebaseMessageSubscriber
+    {
+        /// <summary>
+        /// Subscribes a list of registration tokens to a topic.
+        /// </summary>
+        /// <param name="registrationTokens">A list of registration tokens to subscribe.</param>
+        /// <param name="topic">The topic name to subscribe to. /topics/ will be prepended to the topic name provided if absent.</param>
+        /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving details about the topic subscription operations.</returns>
+        Task<TopicManagementResponse> SubscribeToTopicAsync(
+            IReadOnlyList<string> registrationTokens, string topic);
+
+        /// <summary>
+        /// Unsubscribes a list of registration tokens from a topic.
+        /// </summary>
+        /// <param name="registrationTokens">A list of registration tokens to unsubscribe.</param>
+        /// <param name="topic">The topic name to unsubscribe from. /topics/ will be prepended to the topic name provided if absent.</param>
+        /// <returns>A task that completes with a <see cref="TopicManagementResponse"/>, giving details about the topic unsubscription operations.</returns>
+        Task<TopicManagementResponse> UnsubscribeFromTopicAsync(
+            IReadOnlyList<string> registrationTokens, string topic);
+    }
+}


### PR DESCRIPTION
Add interfaces for FirebaseMessaging to use DI and mocking in the real projects
Move XML comments to the interface to keep it in one place having single implementation and keep the chance to keep a full description using an interface by consumers