### PR TITLE
feat(fcm): Add `SendEachAsync` and `SendEachForMulticastAsync`  for FCM batch send

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
@@ -53,6 +53,78 @@ namespace FirebaseAdmin.IntegrationTests
         }
 
         [Fact]
+        public async Task SendEach()
+        {
+            var message1 = new Message()
+            {
+                Topic = "foo-bar",
+                Notification = new Notification()
+                {
+                    Title = "Title",
+                    Body = "Body",
+                    ImageUrl = "https://example.com/image.png",
+                },
+                Android = new AndroidConfig()
+                {
+                    Priority = Priority.Normal,
+                    TimeToLive = TimeSpan.FromHours(1),
+                    RestrictedPackageName = "com.google.firebase.testing",
+                },
+            };
+            var message2 = new Message()
+            {
+                Topic = "fiz-buz",
+                Notification = new Notification()
+                {
+                    Title = "Title",
+                    Body = "Body",
+                },
+                Android = new AndroidConfig()
+                {
+                    Priority = Priority.Normal,
+                    TimeToLive = TimeSpan.FromHours(1),
+                    RestrictedPackageName = "com.google.firebase.testing",
+                },
+            };
+            var response = await FirebaseMessaging.DefaultInstance.SendEachAsync(new[] { message1, message2 }, dryRun: true);
+            Assert.NotNull(response);
+            Assert.Equal(2, response.SuccessCount);
+            Assert.True(!string.IsNullOrEmpty(response.Responses[0].MessageId));
+            Assert.Matches(new Regex("^projects/.*/messages/.*$"), response.Responses[0].MessageId);
+            Assert.True(!string.IsNullOrEmpty(response.Responses[1].MessageId));
+            Assert.Matches(new Regex("^projects/.*/messages/.*$"), response.Responses[1].MessageId);
+        }
+
+        [Fact]
+        public async Task SendEachForMulticast()
+        {
+            var multicastMessage = new MulticastMessage
+            {
+                Notification = new Notification()
+                {
+                    Title = "Title",
+                    Body = "Body",
+                },
+                Android = new AndroidConfig()
+                {
+                    Priority = Priority.Normal,
+                    TimeToLive = TimeSpan.FromHours(1),
+                    RestrictedPackageName = "com.google.firebase.testing",
+                },
+                Tokens = new[]
+                {
+                    "token1",
+                    "token2",
+                },
+            };
+            var response = await FirebaseMessaging.DefaultInstance.SendEachForMulticastAsync(multicastMessage, dryRun: true);
+            Assert.NotNull(response);
+            Assert.Equal(2, response.FailureCount);
+            Assert.NotNull(response.Responses[0].Exception);
+            Assert.NotNull(response.Responses[1].Exception);
+        }
+
+        [Fact]
         public async Task SendAll()
         {
             var message1 = new Message()

--- a/FirebaseAdmin/FirebaseAdmin.Tests/MockMessageHandler.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/MockMessageHandler.cs
@@ -40,6 +40,10 @@ namespace FirebaseAdmin.Tests
 
         public delegate void SetHeaders(HttpResponseHeaders respHeaders, HttpContentHeaders contentHeaders);
 
+        public delegate object GetResponse(IncomingRequest request);
+
+        public delegate HttpStatusCode GetStatusCode(IncomingRequest request);
+
         /// <summary>
         /// Gets the list of request bodies processed by this handler.
         /// </summary>
@@ -89,6 +93,16 @@ namespace FirebaseAdmin.Tests
         /// </summary>
         public SetHeaders ApplyHeaders { get; set; }
 
+        /// <summary>
+        /// Gets or sets the function for generating the response based on the incoming request.
+        /// </summary>
+        public GetResponse GenerateResponse { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function for generating the status code based on the incoming request.
+        /// </summary>
+        public GetStatusCode GenerateStatusCode { get; set; }
+
         protected override async Task<HttpResponseMessage> DoSendAsync(
             HttpRequestMessage request, int count, CancellationToken cancellationToken)
         {
@@ -100,6 +114,16 @@ namespace FirebaseAdmin.Tests
             {
                 tcs.SetException(this.Exception);
                 return await tcs.Task;
+            }
+
+            if (this.GenerateResponse != null)
+            {
+                this.Response = this.GenerateResponse(incomingRequest);
+            }
+
+            if (this.GenerateStatusCode != null)
+            {
+                this.StatusCode = this.GenerateStatusCode(incomingRequest);
             }
 
             string json;

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
@@ -173,12 +173,13 @@ namespace FirebaseAdmin.Messaging
 
         /// <summary>
         /// Sends each message in the given list via Firebase Cloud Messaging. Unlike
-        /// <see cref="SendAllAsync(IEnumerable{Message})"/>, this method makes a single HTTP call
+        /// <see cref="SendAllAsync(IEnumerable{Message})"/>, this method makes an HTTP call
         /// for each message in the given list.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null or
+        /// empty.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
         public async Task<BatchResponse> SendEachAsync(IEnumerable<Message> messages)
@@ -189,12 +190,13 @@ namespace FirebaseAdmin.Messaging
 
         /// <summary>
         /// Sends each message in the given list via Firebase Cloud Messaging. Unlike
-        /// <see cref="SendAllAsync(IEnumerable{Message}, CancellationToken)"/>, this method makes a
-        /// single HTTP call for each message in the given list.
+        /// <see cref="SendAllAsync(IEnumerable{Message}, CancellationToken)"/>, this method makes
+        /// an HTTP call for each message in the given list.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null or
+        /// empty.</param>
         /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
@@ -207,12 +209,13 @@ namespace FirebaseAdmin.Messaging
 
         /// <summary>
         /// Sends each message in the given list via Firebase Cloud Messaging. Unlike
-        /// <see cref="SendAllAsync(IEnumerable{Message}, bool)"/>, this method makes a
-        /// single HTTP call for each message in the given list.
+        /// <see cref="SendAllAsync(IEnumerable{Message}, bool)"/>, this method makes an HTTP
+        /// call for each message in the given list.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null or
+        /// empty.</param>
         /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
         /// only) of the send. If set to true, the message will be sent to the FCM backend service,
         /// but it will not be delivered to any actual recipients.</param>
@@ -227,11 +230,12 @@ namespace FirebaseAdmin.Messaging
         /// <summary>
         /// Sends each message in the given list via Firebase Cloud Messaging. Unlike
         /// <see cref="SendAllAsync(IEnumerable{Message}, bool, CancellationToken)"/>, this method
-        /// makes a single HTTP call for each message in the given list.
+        /// makes an HTTP call for each message in the given list.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null or
+        /// empty.</param>
         /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
         /// only) of the send. If set to true, the message will be sent to the FCM backend service,
         /// but it will not be delivered to any actual recipients.</param>
@@ -247,12 +251,12 @@ namespace FirebaseAdmin.Messaging
 
         /// <summary>
         /// Sends the given multicast message to all the FCM registration tokens specified in it.
-        /// Unlike <see cref="SendMulticastAsync(MulticastMessage)"/>, this method makes a
-        /// single HTTP call for each token in the given multicast message.
+        /// Unlike <see cref="SendMulticastAsync(MulticastMessage)"/>, this method makes an
+        /// HTTP call for each token in the given multicast message.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
+        /// <param name="message">The message to be sent. Must not be null or empty.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
         public async Task<BatchResponse> SendEachForMulticastAsync(MulticastMessage message)
@@ -264,11 +268,11 @@ namespace FirebaseAdmin.Messaging
         /// <summary>
         /// Sends the given multicast message to all the FCM registration tokens specified in it.
         /// Unlike <see cref="SendMulticastAsync(MulticastMessage, CancellationToken)"/>, this
-        /// method makes a single HTTP call for each token in the given multicast message.
+        /// method makes an HTTP call for each token in the given multicast message.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
+        /// <param name="message">The message to be sent. Must not be null or empty.</param>
         /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
@@ -281,8 +285,8 @@ namespace FirebaseAdmin.Messaging
 
         /// <summary>
         /// Sends the given multicast message to all the FCM registration tokens specified in it.
-        /// Unlike <see cref="SendMulticastAsync(MulticastMessage, bool)"/>, this method makes a
-        /// single HTTP call for each token in the given multicast message.
+        /// Unlike <see cref="SendMulticastAsync(MulticastMessage, bool)"/>, this method makes an
+        /// HTTP call for each token in the given multicast message.
         /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
         /// actually sent to the recipients. Instead, the FCM service performs all the necessary
         /// validations, and emulates the send operation. This is a good way to check if a
@@ -290,7 +294,7 @@ namespace FirebaseAdmin.Messaging
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
+        /// <param name="message">The message to be sent. Must not be null or empty.</param>
         /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
         /// only) of the send. If set to true, the message will be sent to the FCM backend service,
         /// but it will not be delivered to any actual recipients.</param>
@@ -305,7 +309,7 @@ namespace FirebaseAdmin.Messaging
         /// <summary>
         /// Sends the given multicast message to all the FCM registration tokens specified in it.
         /// Unlike <see cref="SendMulticastAsync(MulticastMessage, bool, CancellationToken)"/>,
-        /// this method makes a single HTTP call for each token in the given multicast message.
+        /// this method makes an HTTP call for each token in the given multicast message.
         /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
         /// actually sent to the recipients. Instead, the FCM service performs all the necessary
         /// validations, and emulates the send operation. This is a good way to check if a
@@ -313,7 +317,7 @@ namespace FirebaseAdmin.Messaging
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="message">The message to be sent. Must not be null.</param>
+        /// <param name="message">The message to be sent. Must not be null or empty.</param>
         /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
         /// only) of the send. If set to true, the message will be sent to the FCM backend service,
         /// but it will not be delivered to any actual recipients.</param>

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
@@ -172,15 +172,174 @@ namespace FirebaseAdmin.Messaging
         }
 
         /// <summary>
+        /// Sends each message in the given list via Firebase Cloud Messaging. Unlike
+        /// <see cref="SendAllAsync(IEnumerable{Message})"/>, this method makes a single HTTP call
+        /// for each message in the given list.
+        /// </summary>
+        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
+        /// messages.</exception>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
+        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
+        /// outcome.</returns>
+        public async Task<BatchResponse> SendEachAsync(IEnumerable<Message> messages)
+        {
+            return await this.SendEachAsync(messages, false)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends each message in the given list via Firebase Cloud Messaging. Unlike
+        /// <see cref="SendAllAsync(IEnumerable{Message}, CancellationToken)"/>, this method makes a
+        /// single HTTP call for each message in the given list.
+        /// </summary>
+        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
+        /// messages.</exception>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
+        /// outcome.</returns>
+        public async Task<BatchResponse> SendEachAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)
+        {
+            return await this.SendEachAsync(messages, false, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends each message in the given list via Firebase Cloud Messaging. Unlike
+        /// <see cref="SendAllAsync(IEnumerable{Message}, bool)"/>, this method makes a
+        /// single HTTP call for each message in the given list.
+        /// </summary>
+        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
+        /// messages.</exception>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
+        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
+        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
+        /// but it will not be delivered to any actual recipients.</param>
+        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
+        /// outcome.</returns>
+        public async Task<BatchResponse> SendEachAsync(IEnumerable<Message> messages, bool dryRun)
+        {
+            return await this.SendEachAsync(messages, dryRun, default)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends each message in the given list via Firebase Cloud Messaging. Unlike
+        /// <see cref="SendAllAsync(IEnumerable{Message}, bool, CancellationToken)"/>, this method
+        /// makes a single HTTP call for each message in the given list.
+        /// </summary>
+        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
+        /// messages.</exception>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
+        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
+        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
+        /// but it will not be delivered to any actual recipients.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
+        /// outcome.</returns>
+        public async Task<BatchResponse> SendEachAsync(IEnumerable<Message> messages, bool dryRun, CancellationToken cancellationToken)
+        {
+            return await this.messagingClient.SendEachAsync(messages, dryRun, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Unlike <see cref="SendMulticastAsync(MulticastMessage)"/>, this method makes a
+        /// single HTTP call for each token in the given multicast message.
+        /// </summary>
+        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
+        /// messages.</exception>
+        /// <param name="message">The message to be sent. Must not be null.</param>
+        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
+        /// outcome.</returns>
+        public async Task<BatchResponse> SendEachForMulticastAsync(MulticastMessage message)
+        {
+            return await this.SendEachForMulticastAsync(message, false)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Unlike <see cref="SendMulticastAsync(MulticastMessage, CancellationToken)"/>, this
+        /// method makes a single HTTP call for each token in the given multicast message.
+        /// </summary>
+        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
+        /// messages.</exception>
+        /// <param name="message">The message to be sent. Must not be null.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
+        /// outcome.</returns>
+        public async Task<BatchResponse> SendEachForMulticastAsync(MulticastMessage message, CancellationToken cancellationToken)
+        {
+            return await this.SendEachForMulticastAsync(message, false, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Unlike <see cref="SendMulticastAsync(MulticastMessage, bool)"/>, this method makes a
+        /// single HTTP call for each token in the given multicast message.
+        /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
+        /// actually sent to the recipients. Instead, the FCM service performs all the necessary
+        /// validations, and emulates the send operation. This is a good way to check if a
+        /// certain message will be accepted by FCM for delivery.</para>
+        /// </summary>
+        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
+        /// messages.</exception>
+        /// <param name="message">The message to be sent. Must not be null.</param>
+        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
+        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
+        /// but it will not be delivered to any actual recipients.</param>
+        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
+        /// outcome.</returns>
+        public async Task<BatchResponse> SendEachForMulticastAsync(MulticastMessage message, bool dryRun)
+        {
+            return await this.SendEachForMulticastAsync(message, dryRun, default)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Unlike <see cref="SendMulticastAsync(MulticastMessage, bool, CancellationToken)"/>,
+        /// this method makes a single HTTP call for each token in the given multicast message.
+        /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
+        /// actually sent to the recipients. Instead, the FCM service performs all the necessary
+        /// validations, and emulates the send operation. This is a good way to check if a
+        /// certain message will be accepted by FCM for delivery.</para>
+        /// </summary>
+        /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
+        /// messages.</exception>
+        /// <param name="message">The message to be sent. Must not be null.</param>
+        /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
+        /// only) of the send. If set to true, the message will be sent to the FCM backend service,
+        /// but it will not be delivered to any actual recipients.</param>
+        /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
+        /// operation.</param>
+        /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
+        /// outcome.</returns>
+        public async Task<BatchResponse> SendEachForMulticastAsync(
+            MulticastMessage message, bool dryRun, CancellationToken cancellationToken)
+        {
+            return await this.SendEachAsync(
+                message.GetMessageList(), dryRun, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Sends all the messages in the given list via Firebase Cloud Messaging. Employs batching to
         /// send the entire list as a single RPC call. Compared to the <see cref="SendAsync(Message)"/>
         /// method, this is a significantly more efficient way to send multiple messages.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="messages">Up to 100 messages to send in the batch. Cannot be null.</param>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
+        /// [Obsolete(Use <see cref="SendEachAsync(IEnumerable{Message})"/> instead)]
         public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages)
         {
             return await this.SendAllAsync(messages, false)
@@ -194,11 +353,12 @@ namespace FirebaseAdmin.Messaging
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="messages">Up to 100 messages to send in the batch. Cannot be null.</param>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
         /// <param name="cancellationToken">A cancellation token to monitor the asynchronous
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
+        /// [Obsolete(Use <see cref="SendEachAsync(IEnumerable{Message}, CancellationToken)"/> instead)]
         public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, CancellationToken cancellationToken)
         {
             return await this.SendAllAsync(messages, false, cancellationToken)
@@ -212,12 +372,13 @@ namespace FirebaseAdmin.Messaging
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="messages">Up to 100 messages to send in the batch. Cannot be null.</param>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
         /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
         /// only) of the send. If set to true, the message will be sent to the FCM backend service,
         /// but it will not be delivered to any actual recipients.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
+        /// [Obsolete(Use <see cref="SendEachAsync(IEnumerable{Message}, bool)"/> instead)]
         public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, bool dryRun)
         {
             return await this.SendAllAsync(messages, dryRun, default)
@@ -231,7 +392,7 @@ namespace FirebaseAdmin.Messaging
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
-        /// <param name="messages">Up to 100 messages to send in the batch. Cannot be null.</param>
+        /// <param name="messages">Up to 500 messages to send in the batch. Cannot be null.</param>
         /// <param name="dryRun">A boolean indicating whether to perform a dry run (validation
         /// only) of the send. If set to true, the message will be sent to the FCM backend service,
         /// but it will not be delivered to any actual recipients.</param>
@@ -239,6 +400,7 @@ namespace FirebaseAdmin.Messaging
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
+        /// [Obsolete(Use <see cref="SendEachAsync(IEnumerable{Message}, bool, CancellationToken)"/> instead)]
         public async Task<BatchResponse> SendAllAsync(IEnumerable<Message> messages, bool dryRun, CancellationToken cancellationToken)
         {
             return await this.messagingClient.SendAllAsync(messages, dryRun, cancellationToken)
@@ -253,6 +415,7 @@ namespace FirebaseAdmin.Messaging
         /// <param name="message">The message to be sent. Must not be null.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
+        /// [Obsolete(Use <see cref="SendEachForMulticastAsync(MulticastMessage)"/> instead)]
         public async Task<BatchResponse> SendMulticastAsync(MulticastMessage message)
         {
             return await this.SendMulticastAsync(message, false)
@@ -269,6 +432,7 @@ namespace FirebaseAdmin.Messaging
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
+        /// [Obsolete(Use <see cref="SendEachForMulticastAsync(MulticastMessage, CancellationToken)"/> instead)]
         public async Task<BatchResponse> SendMulticastAsync(MulticastMessage message, CancellationToken cancellationToken)
         {
             return await this.SendMulticastAsync(message, false, cancellationToken)
@@ -290,6 +454,7 @@ namespace FirebaseAdmin.Messaging
         /// but it will not be delivered to any actual recipients.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
+        /// [Obsolete(Use <see cref="SendEachForMulticastAsync(MulticastMessage, bool)"/> instead)]
         public async Task<BatchResponse> SendMulticastAsync(MulticastMessage message, bool dryRun)
         {
             return await this.SendMulticastAsync(message, dryRun, default)
@@ -313,6 +478,7 @@ namespace FirebaseAdmin.Messaging
         /// operation.</param>
         /// <returns>A <see cref="BatchResponse"/> containing details of the batch operation's
         /// outcome.</returns>
+        /// [Obsolete(Use <see cref="SendEachForMulticastAsync(MulticastMessage, bool, CancellationToken)"/> instead)]
         public async Task<BatchResponse> SendMulticastAsync(
             MulticastMessage message, bool dryRun, CancellationToken cancellationToken)
         {


### PR DESCRIPTION
* Deprecate `SendAllAsync`() and `SendMulticastAsync` APIs.
* Add `SendEachAsync` and `SendEachForMulticastAsync` APIs

`SendEachAsync` vs `SendAllAsync`
1. `SendEachAsync` sends one HTTP request to V1 Send endpoint for each message in the list. `SendAllAsync` sends only one HTTP request to V1 Batch Send endpoint to send all messages in the list.
2. `SendEachAsync` calls `Task.WhenAll` to wait for all `httpClient.SendAndDeserializeAsync` calls to complete and construct a `BatchResponse` with all `SendResponse`s. An `httpClient.SendAndDeserializeAsync` call to V1 Send endpoint either completes with a success or throws an exception. So if an exception is thrown out, the exception will be caught in `SendEachAsync` and turned into a `SendResponse` with an exception. Therefore, unlike `SendAllAsync`, `SendEachAsync` does not always throw an exception for a total failure. It can also return a `BatchResponse` with only exceptions in it.

`SendEachForMulticastAsync` calls `SendEachAsync` under the hood.

RELEASE NOTE: `SendAllAsync()` and `SendMulticastAsync()` APIs are now deprecated. Use `SendEachAsync()` and `SendEachForMulticastAsync()` APIs instead.