### PR TITLE
New snippet with project id defined.

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAppSnippets.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAppSnippets.cs
@@ -42,6 +42,17 @@ namespace FirebaseAdmin.Snippets
             // [END initialize_sdk_with_application_default]
         }
 
+        internal static void InitSdkWithApplicationDefaultAndProjectId()
+        {
+            // [START initialize_sdk_with_application_default_and_projectId]
+            FirebaseApp.Create(new AppOptions()
+            {
+                Credential = GoogleCredential.GetApplicationDefault(),
+                ProjectId = "my-project-id",
+            });
+            // [END initialize_sdk_with_application_default_and_projectId]
+        }
+
         internal static void InitSdkWithRefreshToken()
         {
             // [START initialize_sdk_with_refresh_token]


### PR DESCRIPTION
In the internal bug b/290344815 we had been discussing how to initialize SDK and we come up with working version which is different than documentation on the page: https://firebase.google.com/docs/admin/setup?hl=pl#initialize_the_sdk_in_non-google_environments.

This is only part of the change. The second part is done in cider.  cl/555243967