### PR TITLE
chore: Bump supported .NET versions to `net462` and `net6.0`+

### DIFF
--- a/.github/scripts/builder.sh
+++ b/.github/scripts/builder.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+# BUILD_CONFIGURATION=Release
+BUILD_CONFIGURATION=Debug
+
+dotnet restore FirebaseAdmin/FirebaseAdmin.sln
+dotnet build FirebaseAdmin/FirebaseAdmin.sln --configuration $BUILD_CONFIGURATION --no-restore
+dotnet pack FirebaseAdmin/FirebaseAdmin.sln --configuration $BUILD_CONFIGURATION --no-restore
+
+dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration $BUILD_CONFIGURATION
+dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework net6.0 --configuration $BUILD_CONFIGURATION

--- a/.github/scripts/builder.sh
+++ b/.github/scripts/builder.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-set -e
-
-BUILD_CONFIGURATION=Release
-
-dotnet restore FirebaseAdmin/FirebaseAdmin.sln
-dotnet build FirebaseAdmin/FirebaseAdmin.sln --configuration $BUILD_CONFIGURATION --no-restore
-dotnet pack FirebaseAdmin/FirebaseAdmin.sln --configuration $BUILD_CONFIGURATION --no-restore

--- a/.github/scripts/builder.sh
+++ b/.github/scripts/builder.sh
@@ -2,12 +2,8 @@
 
 set -e
 
-# BUILD_CONFIGURATION=Release
-BUILD_CONFIGURATION=Debug
+BUILD_CONFIGURATION=Release
 
 dotnet restore FirebaseAdmin/FirebaseAdmin.sln
 dotnet build FirebaseAdmin/FirebaseAdmin.sln --configuration $BUILD_CONFIGURATION --no-restore
 dotnet pack FirebaseAdmin/FirebaseAdmin.sln --configuration $BUILD_CONFIGURATION --no-restore
-
-dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration $BUILD_CONFIGURATION
-dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework net6.0 --configuration $BUILD_CONFIGURATION

--- a/.github/scripts/run_integration_tests.sh
+++ b/.github/scripts/run_integration_tests.sh
@@ -25,6 +25,6 @@ gpg --quiet --batch --yes --decrypt --passphrase="${FIREBASE_SERVICE_ACCT_KEY}" 
 
 echo "${FIREBASE_API_KEY}" > FirebaseAdmin/FirebaseAdmin.IntegrationTests/resources/integration_apikey.txt
 
-dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --no-restore --no-build --framework netcoreapp3.1
-dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --no-restore --no-build --framework net462
-dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --no-restore --no-build --framework net6.0
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --framework netcoreapp3.1
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --framework net462
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --framework net6.0

--- a/.github/scripts/run_integration_tests.sh
+++ b/.github/scripts/run_integration_tests.sh
@@ -25,6 +25,5 @@ gpg --quiet --batch --yes --decrypt --passphrase="${FIREBASE_SERVICE_ACCT_KEY}" 
 
 echo "${FIREBASE_API_KEY}" > FirebaseAdmin/FirebaseAdmin.IntegrationTests/resources/integration_apikey.txt
 
-dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --framework netcoreapp3.1
 dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --framework net462
 dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --framework net6.0

--- a/.github/scripts/run_integration_tests.sh
+++ b/.github/scripts/run_integration_tests.sh
@@ -25,5 +25,5 @@ gpg --quiet --batch --yes --decrypt --passphrase="${FIREBASE_SERVICE_ACCT_KEY}" 
 
 echo "${FIREBASE_API_KEY}" > FirebaseAdmin/FirebaseAdmin.IntegrationTests/resources/integration_apikey.txt
 
-dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --no-build --framework netcoreapp3.1 --configuration Release
-dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --no-build --framework net6.0 --configuration Release
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --framework netcoreapp3.1 --configuration Release
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --framework net6.0 --configuration Release

--- a/.github/scripts/run_integration_tests.sh
+++ b/.github/scripts/run_integration_tests.sh
@@ -25,4 +25,5 @@ gpg --quiet --batch --yes --decrypt --passphrase="${FIREBASE_SERVICE_ACCT_KEY}" 
 
 echo "${FIREBASE_API_KEY}" > FirebaseAdmin/FirebaseAdmin.IntegrationTests/resources/integration_apikey.txt
 
-dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --no-build --framework netcoreapp3.1 --configuration Release
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --no-build --framework net6.0 --configuration Release

--- a/.github/scripts/run_integration_tests.sh
+++ b/.github/scripts/run_integration_tests.sh
@@ -25,5 +25,6 @@ gpg --quiet --batch --yes --decrypt --passphrase="${FIREBASE_SERVICE_ACCT_KEY}" 
 
 echo "${FIREBASE_API_KEY}" > FirebaseAdmin/FirebaseAdmin.IntegrationTests/resources/integration_apikey.txt
 
-dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --framework netcoreapp3.1 --configuration Release
-dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --framework net6.0 --configuration Release
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --no-restore --no-build --framework netcoreapp3.1
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --no-restore --no-build --framework net462
+dotnet test FirebaseAdmin/FirebaseAdmin.IntegrationTests --configuration Release --no-restore --no-build --framework net6.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,4 @@ jobs:
 
     - name: Run unit tests
       run: |
-        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration Release
+        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,10 @@ jobs:
       with:
         dotnet-version: ${{ matrix.dotnet-version }}
 
-    - name: Install dependencies
-      run: dotnet msbuild /t:restore FirebaseAdmin
-
     - name: Build with dotnet
-      run: |
-        dotnet msbuild FirebaseAdmin/FirebaseAdmin
-        dotnet msbuild FirebaseAdmin/FirebaseAdmin.Snippets
-        dotnet msbuild FirebaseAdmin/FirebaseAdmin.IntegrationTests
+      run: ./github/scripts/./builder.sh
 
     - name: Run unit tests
-      run: dotnet test FirebaseAdmin/FirebaseAdmin.Tests
+      run: |
+        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration Release
+        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework net6.0 --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup .NET 6
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 6.0.x
+    # - name: Setup .NET 6
+    #   uses: actions/setup-dotnet@v4
+    #   with:
+    #     dotnet-version: 6.0.x
 
     - name: Setup .NET 3.1
       uses: actions/setup-dotnet@v4
@@ -38,4 +38,3 @@ jobs:
     - name: Run unit tests
       run: |
         dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration Release
-        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework net6.0 --configuration Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        framework-version: [netcoreapp3.1, net462, net6.0, net7.0, net8.0]
 
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -19,15 +20,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup .NET 6
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
-
-    - name: Setup .NET 3.1
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 3.1.x
+        dotnet-version: |
+          3.1.x
+          6.0.x
+          7.0.x
+          8.0.x
 
     - name: Install dependencies
       run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln
@@ -37,4 +37,4 @@ jobs:
 
     - name: Run unit tests
       run: |
-        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --configuration Release
+        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --configuration Release --no-restore --no-build --framework ${{ matrix.framework-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup .NET Core 2.1
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,16 @@ on: pull_request
 
 jobs:
   build:
-
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
 
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        framework-version: [netcoreapp3.1, net462, net6.0, net7.0, net8.0]
+        framework-version: [net462, net6.0]
 
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -23,11 +23,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
-          7.0.x
-          8.0.x
+        dotnet-version: 6.0.x
 
     - name: Install dependencies
       run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         dotnet-version: ${{ matrix.dotnet-version }}
 
     - name: Build with dotnet
-      run: ./github/scripts/./builder.sh
+      run: .github/scripts/./builder.sh
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        dotnet-version: [ 3.1.x, 6.0.x ]
 
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
@@ -17,12 +18,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     - name: Setup .NET Core 2.1
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 2.1.x
+        dotnet-version: ${{ matrix.dotnet-version }}
 
     - name: Install dependencies
       run: dotnet msbuild /t:restore FirebaseAdmin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,29 +4,33 @@ on: pull_request
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        dotnet-version: [ 3.1.x, 6.0.x ]
+
+    runs-on: ubuntu-latest
 
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_CLI_TELEMETRY_OPTOUT: 1
       DOTNET_NOLOGO: 1
 
-    runs-on: ${{ matrix.os }}
-
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Setup .NET
+    - name: Setup .NET 6
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: ${{ matrix.dotnet-version }}
+        dotnet-version: 6.0.x
+
+    - name: Setup .NET 3.1
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 3.1.x
+
+    - name: Install dependencies
+      run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln
 
     - name: Build with dotnet
-      run: .github/scripts/./builder.sh
+      run: dotnet build FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    # - name: Setup .NET 6
-    #   uses: actions/setup-dotnet@v4
-    #   with:
-    #     dotnet-version: 6.0.x
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 6.0.x
 
     - name: Setup .NET 3.1
       uses: actions/setup-dotnet@v4
@@ -37,4 +37,4 @@ jobs:
 
     - name: Run unit tests
       run: |
-        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --configuration Release
+        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --configuration Release

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,11 +41,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
-          7.0.x
-          8.0.x
+        dotnet-version: 6.0.x
 
     - name: Install dependencies
       run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,15 +38,14 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
         
-    - name: Setup .NET 6.0
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
-
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 3.1.x
+        dotnet-version: |
+          3.1.x
+          6.0.x
+          7.0.x
+          8.0.x
 
     - name: Install dependencies
       run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln
@@ -55,19 +54,16 @@ jobs:
       run: dotnet build FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
 
     - name: Run unit tests
-      run: dotnet test FirebaseAdmin/FirebaseAdmin.Tests
+      run: dotnet test FirebaseAdmin/FirebaseAdmin.Tests --configuration Release --no-restore --no-build
 
     - name: Run integration tests
-      run: |
-        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration Release
-        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework net6.0 --configuration Release
-      
+      run: ./.github/scripts/run_integration_tests.sh
       env:
         FIREBASE_SERVICE_ACCT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCT_KEY }}
         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
 
     - name: Package release artifacts
-      run: dotnet pack FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
+      run: dotnet pack FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore --no-build
 
 
     # Attach the packaged artifacts to the workflow output. These can be manually

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,32 +34,41 @@ jobs:
 
     steps:
     - name: Checkout source for staging
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
         
-    - name: Setup .NET Core 2.1
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 2.1.x
+        dotnet-version: 6.0.x
+
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 3.1.x
 
     - name: Install dependencies
-      run: dotnet msbuild /t:restore FirebaseAdmin
+      run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln
 
     - name: Build with dotnet
-      run: dotnet msbuild FirebaseAdmin/FirebaseAdmin
+      run: dotnet build FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
 
     - name: Run unit tests
       run: dotnet test FirebaseAdmin/FirebaseAdmin.Tests
 
     - name: Run integration tests
-      run: ./.github/scripts/run_integration_tests.sh
+      run: |
+        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration Release
+        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework net6.0 --configuration Release
+      
       env:
         FIREBASE_SERVICE_ACCT_KEY: ${{ secrets.FIREBASE_SERVICE_ACCT_KEY }}
         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
 
     - name: Package release artifacts
-      run: dotnet pack -c Release FirebaseAdmin/FirebaseAdmin
+      run: dotnet pack FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
+
 
     # Attach the packaged artifacts to the workflow output. These can be manually
     # downloaded for later inspection if necessary.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,23 +46,30 @@ jobs:
     # via the 'ref' client parameter.
     steps:
     - name: Checkout source for staging
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
-    - name: Setup .NET Core 2.1
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 2.1.x
+        dotnet-version: 6.0.x
+
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 3.1.x
 
     - name: Install dependencies
-      run: dotnet msbuild /t:restore FirebaseAdmin
+      run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln
 
     - name: Build with dotnet
-      run: dotnet msbuild FirebaseAdmin/FirebaseAdmin
+      run: dotnet build FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
 
     - name: Run unit tests
-      run: dotnet test FirebaseAdmin/FirebaseAdmin.Tests
+      run: 
+        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration Release
+        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework net6.0 --configuration Release
 
     - name: Run integration tests
       run: ./.github/scripts/run_integration_tests.sh
@@ -71,7 +78,7 @@ jobs:
         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
 
     - name: Package release artifacts
-      run: dotnet pack -c Release FirebaseAdmin/FirebaseAdmin
+      run: dotnet pack FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
 
     # Attach the packaged artifacts to the workflow output. These can be manually
     # downloaded for later inspection if necessary.
@@ -100,7 +107,7 @@ jobs:
 
     steps:
     - name: Checkout source for publish
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Download the artifacts created by the stage_release job.
     - name: Download release candidates
@@ -108,10 +115,15 @@ jobs:
       with:
         name: Release
 
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET 6
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 2.2.108
+        dotnet-version: 6.0.x
+
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 3.1.x
 
     - name: Publish preflight check
       id: preflight

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
-          7.0.x
-          8.0.x
+        dotnet-version: 6.0.x
 
     - name: Install dependencies
       run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln
@@ -115,11 +111,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: |
-          3.1.x
-          6.0.x
-          7.0.x
-          8.0.x
+        dotnet-version: 6.0.x
 
     - name: Publish preflight check
       id: preflight

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,15 +50,14 @@ jobs:
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
 
-    - name: Setup .NET 6
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
-
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 3.1.x
+        dotnet-version: |
+          3.1.x
+          6.0.x
+          7.0.x
+          8.0.x
 
     - name: Install dependencies
       run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln
@@ -67,9 +66,7 @@ jobs:
       run: dotnet build FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
 
     - name: Run unit tests
-      run: |
-        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration Release
-        dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework net6.0 --configuration Release
+      run: dotnet test FirebaseAdmin/FirebaseAdmin.Tests --configuration Release --no-restore --no-build
 
     - name: Run integration tests
       run: ./.github/scripts/run_integration_tests.sh
@@ -78,7 +75,7 @@ jobs:
         FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
 
     - name: Package release artifacts
-      run: dotnet pack FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
+      run: dotnet pack FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore --no-build
 
     # Attach the packaged artifacts to the workflow output. These can be manually
     # downloaded for later inspection if necessary.
@@ -115,15 +112,14 @@ jobs:
       with:
         name: Release
 
-    - name: Setup .NET 6
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 6.0.x
-
-    - name: Setup .NET Core 3.1
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 3.1.x
+        dotnet-version: |
+          3.1.x
+          6.0.x
+          7.0.x
+          8.0.x
 
     - name: Publish preflight check
       id: preflight

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       run: dotnet build FirebaseAdmin/FirebaseAdmin.sln --configuration Release --no-restore
 
     - name: Run unit tests
-      run: 
+      run: |
         dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework netcoreapp3.1 --configuration Release
         dotnet test FirebaseAdmin/FirebaseAdmin.Tests --no-build --framework net6.0 --configuration Release
 

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractFirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractFirebaseAuthTest.cs
@@ -17,10 +17,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Web;
 using FirebaseAdmin.Auth;
 using FirebaseAdmin.Auth.Hash;
 using Google.Apis.Auth.OAuth2;
+using Microsoft.AspNetCore.WebUtilities;
 using Xunit;
 
 namespace FirebaseAdmin.IntegrationTests.Auth
@@ -603,7 +603,7 @@ namespace FirebaseAdmin.IntegrationTests.Auth
                 user.Email, EmailLinkSettings);
 
             var uri = new Uri(link);
-            var query = HttpUtility.ParseQueryString(uri.Query);
+            var query = QueryHelpers.ParseQuery(uri.Query);
             Assert.Equal(ContinueUrl, query["continueUrl"]);
             Assert.Equal("verifyEmail", query["mode"]);
         }
@@ -617,7 +617,7 @@ namespace FirebaseAdmin.IntegrationTests.Auth
                 user.Email, EmailLinkSettings);
 
             var uri = new Uri(link);
-            var query = HttpUtility.ParseQueryString(uri.Query);
+            var query = QueryHelpers.ParseQuery(uri.Query);
             Assert.Equal(ContinueUrl, query["continueUrl"]);
 
             var request = new ResetPasswordRequest()
@@ -645,7 +645,7 @@ namespace FirebaseAdmin.IntegrationTests.Auth
                 user.Email, EmailLinkSettings);
 
             var uri = new Uri(link);
-            var query = HttpUtility.ParseQueryString(uri.Query);
+            var query = QueryHelpers.ParseQuery(uri.Query);
             Assert.Equal(ContinueUrl, query["continueUrl"]);
 
             var idToken = await AuthIntegrationUtils.SignInWithEmailLinkAsync(

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" /> 
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" /> 
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" /> 
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
@@ -20,6 +20,10 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
+    <Reference Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" /> 
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -21,11 +21,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
-    <Reference Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\FirebaseAdmin\FirebaseAdmin.csproj" />
   </ItemGroup>

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -12,13 +12,22 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" /> 
     <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp3.1'">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" /> 
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseAdmin.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net462;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -12,22 +12,13 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" /> 
     <PackageReference Include="xunit" Version="2.7.0" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp3.1'">
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net462;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0;</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>../../stylecop_test.ruleset</CodeAnalysisRuleSet>

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>../../stylecop_test.ruleset</CodeAnalysisRuleSet>

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAdmin.Snippets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>../../stylecop_test.ruleset</CodeAnalysisRuleSet>

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAuthSnippets.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseAuthSnippets.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using FirebaseAdmin.Auth;
@@ -582,9 +583,10 @@ namespace FirebaseAdmin.Snippets
             object isAdmin;
             if (user.CustomClaims.TryGetValue("admin", out isAdmin) && (bool)isAdmin)
             {
-                var claims = new Dictionary<string, object>(user.CustomClaims);
+                var claims = user.CustomClaims.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
                 // Add level.
-                claims["level"] = 10;
+                var level = 10;
+                claims["level"] = level;
                 // Add custom claims for additional privileges.
                 await FirebaseAuth.DefaultInstance.SetCustomUserClaimsAsync(user.Uid, claims);
             }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthBuilder.cs
@@ -64,19 +64,19 @@ namespace FirebaseAdmin.Auth.Tests
             if (options.UserManagerRequestHandler != null)
             {
                 args.UserManager = new Lazy<FirebaseUserManager>(
-                    this.CreateUserManager(options));
+                    () => this.CreateUserManager(options));
             }
 
             if (options.ProviderConfigRequestHandler != null)
             {
                 args.ProviderConfigManager = new Lazy<ProviderConfigManager>(
-                    this.CreateProviderConfigManager(options));
+                    () => this.CreateProviderConfigManager(options));
             }
 
             if (options.IdTokenVerifier)
             {
                 args.IdTokenVerifier = new Lazy<FirebaseTokenVerifier>(
-                    this.CreateIdTokenVerifier());
+                    () => this.CreateIdTokenVerifier());
             }
 
             if (options.SessionCookieVerifier)
@@ -84,7 +84,7 @@ namespace FirebaseAdmin.Auth.Tests
                 if (args is FirebaseAuth.Args)
                 {
                     (args as FirebaseAuth.Args).SessionCookieVerifier =
-                        new Lazy<FirebaseTokenVerifier>(this.CreateSessionCookieVerifier());
+                        new Lazy<FirebaseTokenVerifier>(() => this.CreateSessionCookieVerifier());
                 }
                 else
                 {
@@ -95,7 +95,7 @@ namespace FirebaseAdmin.Auth.Tests
 
             if (options.TokenFactory)
             {
-                args.TokenFactory = new Lazy<FirebaseTokenFactory>(this.CreateTokenFactory());
+                args.TokenFactory = new Lazy<FirebaseTokenFactory>(() => this.CreateTokenFactory());
             }
         }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/CustomTokenVerifier.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/CustomTokenVerifier.cs
@@ -45,7 +45,7 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
 
         internal void Verify(string token, string uid, IDictionary<string, object> claims = null)
         {
-            string[] segments = token.Split(".");
+            string[] segments = token.Split('.');
             Assert.Equal(3, segments.Length);
 
             var header = JwtUtils.Decode<JsonWebSignature.Header>(segments[0]);
@@ -99,7 +99,7 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
             : base(issuer, tenantId)
             {
                 var x509cert = new X509Certificate2(publicKey);
-                this.rsa = (RSA)x509cert.PublicKey.Key;
+                this.rsa = (RSA)x509cert.GetRSAPublicKey();
             }
 
             protected override void AssertSignature(string tokenData, string signature)

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/JwtTestUtils.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/JwtTestUtils.cs
@@ -113,7 +113,7 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
             public ByteArrayPublicKeySource(byte[] publicKey)
             {
                 var x509cert = new X509Certificate2(publicKey);
-                var rsa = (RSA)x509cert.PublicKey.Key;
+                var rsa = (RSA)x509cert.GetRSAPublicKey();
                 this.rsa = ImmutableList.Create(new PublicKey("test-key-id", rsa));
             }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/ServiceAccountSignerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/ServiceAccountSignerTest.cs
@@ -34,7 +34,7 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
             Assert.Equal(
                 "client@test-project.iam.gserviceaccount.com", await signer.GetKeyIdAsync());
             byte[] data = Encoding.UTF8.GetBytes("Hello world");
-            byte[] signature = signer.SignDataAsync(data).Result;
+            byte[] signature = await signer.SignDataAsync(data);
             Assert.True(this.Verify(data, signature));
         }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/ServiceAccountSignerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Jwt/ServiceAccountSignerTest.cs
@@ -47,7 +47,7 @@ namespace FirebaseAdmin.Auth.Jwt.Tests
         private bool Verify(byte[] data, byte[] signature)
         {
             var x509cert = new X509Certificate2(File.ReadAllBytes("./resources/public_cert.pem"));
-            var rsa = (RSA)x509cert.PublicKey.Key;
+            var rsa = (RSA)x509cert.GetRSAPublicKey();
             return rsa.VerifyData(
                 data, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
         }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantManagerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantManagerTest.cs
@@ -93,7 +93,7 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
             var provider = await auth.TenantManager.GetTenantAsync("tenant1");
 
             AssertTenant(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpMethod.Get, request.Method);
             config.AssertRequest("tenants/tenant1", request);
@@ -152,7 +152,7 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
             var provider = await auth.TenantManager.CreateTenantAsync(args);
 
             AssertTenant(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpMethod.Post, request.Method);
             config.AssertRequest("tenants", request);
@@ -178,7 +178,7 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
             var provider = await auth.TenantManager.CreateTenantAsync(new TenantArgs());
 
             AssertTenant(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpMethod.Post, request.Method);
             config.AssertRequest("tenants", request);
@@ -239,7 +239,7 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
             var provider = await auth.TenantManager.UpdateTenantAsync("tenant1", args);
 
             AssertTenant(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpUtils.Patch, request.Method);
             var mask = "allowPasswordSignup,displayName,enableEmailLinkSignin";
@@ -270,7 +270,7 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
             var provider = await auth.TenantManager.UpdateTenantAsync("tenant1", args);
 
             AssertTenant(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpUtils.Patch, request.Method);
             config.AssertRequest("tenants/tenant1?updateMask=displayName", request);
@@ -354,7 +354,7 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
 
             await auth.TenantManager.DeleteTenantAsync("tenant1");
 
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpMethod.Delete, request.Method);
             config.AssertRequest("tenants/tenant1", request);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantManagerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Multitenancy/TenantManagerTest.cs
@@ -77,7 +77,7 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
         {
             var strings = new List<string>() { null, string.Empty };
             return TestConfigs.SelectMany(
-                config => strings, (config, str) => config.Append(str).ToArray());
+                config => strings, (config, str) => config.Concat(new object[] { str }).ToArray());
         }
 
         [Theory]
@@ -669,7 +669,7 @@ namespace FirebaseAdmin.Auth.Multitenancy.Tests
                     EmulatorHost = this.EmulatorHost,
                 });
                 var args = FirebaseAuth.Args.CreateDefault();
-                args.TenantManager = new Lazy<TenantManager>(tenantManager);
+                args.TenantManager = new Lazy<TenantManager>(() => tenantManager);
                 return new FirebaseAuth(args);
             }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Providers/OidcProviderConfigTest.cs
@@ -72,7 +72,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             var provider = await auth.GetOidcProviderConfigAsync("oidc.provider");
 
             this.AssertOidcProviderConfig(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpMethod.Get, request.Method);
             config.AssertRequest("oauthIdpConfigs/oidc.provider", request);
@@ -148,7 +148,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             var provider = await auth.CreateProviderConfigAsync(args);
 
             this.AssertOidcProviderConfig(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpMethod.Post, request.Method);
             config.AssertRequest("oauthIdpConfigs?oauthIdpConfigId=oidc.provider", request);
@@ -184,7 +184,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             var provider = await auth.CreateProviderConfigAsync(args);
 
             this.AssertOidcProviderConfig(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpMethod.Post, request.Method);
             config.AssertRequest(
@@ -271,7 +271,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             var provider = await auth.UpdateProviderConfigAsync(args);
 
             this.AssertOidcProviderConfig(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(ProviderTestConfig.PatchMethod, request.Method);
             var mask = "clientId,clientSecret,displayName,enabled,issuer,responseType.code,responseType.idToken";
@@ -307,7 +307,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
             var provider = await auth.UpdateProviderConfigAsync(args);
 
             this.AssertOidcProviderConfig(provider);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(ProviderTestConfig.PatchMethod, request.Method);
             config.AssertRequest(
@@ -382,7 +382,7 @@ namespace FirebaseAdmin.Auth.Providers.Tests
 
             await auth.DeleteProviderConfigAsync("oidc.provider");
 
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = handler.Requests[0];
             Assert.Equal(HttpMethod.Delete, request.Method);
             config.AssertRequest("oauthIdpConfigs/oidc.provider", request);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/EmailActionRequestTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/EmailActionRequestTest.cs
@@ -92,42 +92,42 @@ namespace FirebaseAdmin.Auth.Users.Tests
         };
 
         [Fact]
-        public void NoEmail()
+        public async void NoEmail()
         {
             var handler = new MockMessageHandler() { Response = GenerateEmailLinkResponse };
             var auth = this.CreateFirebaseAuth(handler);
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.GenerateEmailVerificationLinkAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.GenerateEmailVerificationLinkAsync(string.Empty));
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.GeneratePasswordResetLinkAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.GeneratePasswordResetLinkAsync(string.Empty));
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.GenerateSignInWithEmailLinkAsync(null, ActionCodeSettings));
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.GenerateSignInWithEmailLinkAsync(string.Empty, ActionCodeSettings));
         }
 
         [Theory]
         [MemberData(nameof(InvalidActionCodeSettingsArgs))]
-        public void InvalidActionCodeSettings(ActionCodeSettings settings)
+        public async void InvalidActionCodeSettings(ActionCodeSettings settings)
         {
             var handler = new MockMessageHandler() { Response = GenerateEmailLinkResponse };
             var auth = this.CreateFirebaseAuth(handler);
             var email = "user@example.com";
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.GenerateEmailVerificationLinkAsync(email, settings));
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.GeneratePasswordResetLinkAsync(email, settings));
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.GenerateSignInWithEmailLinkAsync(email, settings));
         }
 
@@ -264,13 +264,13 @@ namespace FirebaseAdmin.Auth.Users.Tests
         }
 
         [Fact]
-        public void SignInWithEmailLinkNoSettings()
+        public async void SignInWithEmailLinkNoSettings()
         {
             var handler = new MockMessageHandler() { Response = GenerateEmailLinkResponse };
             var auth = this.CreateFirebaseAuth(handler);
             var email = "user@example.com";
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentNullException>(
                 async () => await auth.GenerateSignInWithEmailLinkAsync(email, null));
         }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/EmailActionRequestTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/EmailActionRequestTest.cs
@@ -361,7 +361,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
                 RetryOptions = RetryOptions.NoBackOff,
             });
             var args = FirebaseAuth.Args.CreateDefault();
-            args.UserManager = new Lazy<FirebaseUserManager>(userManager);
+            args.UserManager = new Lazy<FirebaseUserManager>(() => userManager);
             return new FirebaseAuth(args);
         }
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/FirebaseUserManagerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/Users/FirebaseUserManagerTest.cs
@@ -564,7 +564,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
 
             Assert.Equal("token", userPage.NextPageToken);
             Assert.Equal(3, userPage.Count());
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             config.AssertRequest(
                 "accounts:batchGet?maxResults=3", Assert.Single(handler.Requests));
 
@@ -1302,7 +1302,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
 
         [Theory]
         [MemberData(nameof(TestConfigs))]
-        public void ReservedClaims(TestConfig config)
+        public async void ReservedClaims(TestConfig config)
         {
             var handler = new MockMessageHandler();
             var auth = config.CreateAuth(handler);
@@ -1314,14 +1314,14 @@ namespace FirebaseAdmin.Auth.Users.Tests
                     { key, "value" },
                 };
 
-                Assert.ThrowsAsync<ArgumentException>(
+                await Assert.ThrowsAsync<ArgumentException>(
                     async () => await auth.SetCustomUserClaimsAsync("user1", customClaims));
             }
         }
 
         [Theory]
         [MemberData(nameof(TestConfigs))]
-        public void UpdateUserNoUid(TestConfig config)
+        public async void UpdateUserNoUid(TestConfig config)
         {
             var handler = new MockMessageHandler();
             var auth = config.CreateAuth(handler);
@@ -1330,12 +1330,12 @@ namespace FirebaseAdmin.Auth.Users.Tests
             {
                 EmailVerified = true,
             };
-            Assert.ThrowsAsync<ArgumentException>(async () => await auth.UpdateUserAsync(args));
+            await Assert.ThrowsAsync<ArgumentNullException>(async () => await auth.UpdateUserAsync(args));
         }
 
         [Theory]
         [MemberData(nameof(TestConfigs))]
-        public void UpdateUserInvalidUid(TestConfig config)
+        public async void UpdateUserInvalidUid(TestConfig config)
         {
             var handler = new MockMessageHandler();
             var auth = config.CreateAuth(handler);
@@ -1345,7 +1345,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
                 EmailVerified = true,
                 Uid = new string('a', 129),
             };
-            Assert.ThrowsAsync<ArgumentException>(async () => await auth.UpdateUserAsync(args));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await auth.UpdateUserAsync(args));
         }
 
         [Theory]
@@ -1487,7 +1487,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
 
         [Theory]
         [MemberData(nameof(TestConfigs))]
-        public void EmptyNameClaims(TestConfig config)
+        public async void EmptyNameClaims(TestConfig config)
         {
             var handler = new MockMessageHandler();
             var auth = config.CreateAuth(handler);
@@ -1496,13 +1496,13 @@ namespace FirebaseAdmin.Auth.Users.Tests
                     { string.Empty, "value" },
             };
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.SetCustomUserClaimsAsync("user1", emptyClaims));
         }
 
         [Theory]
         [MemberData(nameof(TestConfigs))]
-        public void LargeClaimsOverLimit(TestConfig config)
+        public async void LargeClaimsOverLimit(TestConfig config)
         {
             var handler = new MockMessageHandler();
             var auth = config.CreateAuth(handler);
@@ -1511,7 +1511,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
                 { "testClaim", new string('a', 1001) },
             };
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.SetCustomUserClaimsAsync("user1", largeClaims));
         }
 
@@ -1721,7 +1721,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
 
             await auth.RevokeRefreshTokensAsync("user1");
 
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = NewtonsoftJsonSerializer.Instance.Deserialize<JObject>(handler.LastRequestBody);
             Assert.Equal(2, request.Count);
             Assert.Equal("user1", request["localId"]);
@@ -1732,31 +1732,31 @@ namespace FirebaseAdmin.Auth.Users.Tests
 
         [Theory]
         [MemberData(nameof(TestConfigs))]
-        public void RevokeRefreshTokensNoUid(TestConfig config)
+        public async void RevokeRefreshTokensNoUid(TestConfig config)
         {
             var handler = new MockMessageHandler() { Response = CreateUserResponse };
             var auth = config.CreateAuth(handler);
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentNullException>(
                 async () => await auth.RevokeRefreshTokensAsync(null));
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.RevokeRefreshTokensAsync(string.Empty));
         }
 
         [Theory]
         [MemberData(nameof(TestConfigs))]
-        public void RevokeRefreshTokensInvalidUid(TestConfig config)
+        public async void RevokeRefreshTokensInvalidUid(TestConfig config)
         {
             var auth = config.CreateAuth(new MockMessageHandler());
 
             var uid = new string('a', 129);
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.RevokeRefreshTokensAsync(uid));
         }
 
         [Theory]
         [MemberData(nameof(MainTenantTestConfigs))]
-        public void CreateSessionCookieNoIdToken(TestConfig config)
+        public async void CreateSessionCookieNoIdToken(TestConfig config)
         {
             var handler = new MockMessageHandler() { Response = "{}" };
             var auth = (FirebaseAuth)config.CreateAuth(handler);
@@ -1765,31 +1765,31 @@ namespace FirebaseAdmin.Auth.Users.Tests
                 ExpiresIn = TimeSpan.FromHours(1),
             };
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.CreateSessionCookieAsync(null, options));
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.CreateSessionCookieAsync(string.Empty, options));
         }
 
         [Theory]
         [MemberData(nameof(MainTenantTestConfigs))]
-        public void CreateSessionCookieNoOptions(TestConfig config)
+        public async void CreateSessionCookieNoOptions(TestConfig config)
         {
             var handler = new MockMessageHandler() { Response = "{}" };
             var auth = (FirebaseAuth)config.CreateAuth(handler);
 
-            Assert.ThrowsAsync<ArgumentNullException>(
+            await Assert.ThrowsAsync<ArgumentNullException>(
                 async () => await auth.CreateSessionCookieAsync("idToken", null));
         }
 
         [Theory]
         [MemberData(nameof(MainTenantTestConfigs))]
-        public void CreateSessionCookieNoExpiresIn(TestConfig config)
+        public async void CreateSessionCookieNoExpiresIn(TestConfig config)
         {
             var handler = new MockMessageHandler() { Response = "{}" };
             var auth = (FirebaseAuth)config.CreateAuth(handler);
 
-            Assert.ThrowsAsync<ArgumentException>(
+            await Assert.ThrowsAsync<ArgumentException>(
                 async () => await auth.CreateSessionCookieAsync(
                     "idToken", new SessionCookieOptions()));
         }
@@ -1846,7 +1846,7 @@ namespace FirebaseAdmin.Auth.Users.Tests
             var result = await auth.CreateSessionCookieAsync(idToken, options);
 
             Assert.Equal("cookie", result);
-            Assert.Equal(1, handler.Requests.Count);
+            Assert.Single(handler.Requests);
             var request = NewtonsoftJsonSerializer.Instance.Deserialize<JObject>(handler.LastRequestBody);
             Assert.Equal(2, request.Count);
             Assert.Equal(idToken, request["idToken"]);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net462;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net462;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>
@@ -19,26 +19,15 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
     <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp3.1'">
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\FirebaseAdmin\FirebaseAdmin.csproj" />
   </ItemGroup>

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
@@ -19,15 +19,26 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
     <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'!='netcoreapp3.1'">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp3.1'">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\FirebaseAdmin\FirebaseAdmin.csproj" />
   </ItemGroup>

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
@@ -18,8 +18,8 @@
     <PackageReference Include="Google.Apis.Auth" Version="1.49.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -28,11 +28,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
-    <Reference Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\FirebaseAdmin\FirebaseAdmin.csproj" />
   </ItemGroup>

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Google.Apis.Auth" Version="1.49.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
@@ -27,6 +27,10 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
+    <Reference Include="Microsoft.TestPlatform.ObjectModel" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>
@@ -18,8 +18,8 @@
     <PackageReference Include="Google.Apis.Auth" Version="1.49.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAdmin.Tests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Google.Apis.Auth" Version="1.49.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAppTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/FirebaseAppTest.cs
@@ -250,7 +250,7 @@ namespace FirebaseAdmin.Tests
         {
             var version = FirebaseApp.GetSdkVersion();
 
-            var segments = version.Split(".");
+            var segments = version.Split('.');
             Assert.Equal(3, segments.Length);
             int result;
             Assert.All(segments, (segment) => int.TryParse(segment, out result));

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/BatchResponseTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/BatchResponseTest.cs
@@ -31,7 +31,7 @@ namespace FirebaseAdmin.Tests.Messaging
 
             Assert.Equal(0, batchResponse.SuccessCount);
             Assert.Equal(0, batchResponse.FailureCount);
-            Assert.Equal(0, batchResponse.Responses.Count);
+            Assert.Empty(batchResponse.Responses);
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingTest.cs
@@ -99,9 +99,16 @@ namespace FirebaseAdmin.Messaging.Tests
             FirebaseApp.Create(new AppOptions() { Credential = MockCredential });
             var canceller = new CancellationTokenSource();
             canceller.Cancel();
+
+            #if NET6_0_OR_GREATER
             await Assert.ThrowsAsync<TaskCanceledException>(
                 async () => await FirebaseMessaging.DefaultInstance.SendAsync(
                     new Message() { Topic = "test-topic" }, canceller.Token));
+            #else
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await FirebaseMessaging.DefaultInstance.SendAsync(
+                    new Message() { Topic = "test-topic" }, canceller.Token));
+            #endif
         }
 
         [Fact]
@@ -114,9 +121,16 @@ namespace FirebaseAdmin.Messaging.Tests
             });
             var canceller = new CancellationTokenSource();
             canceller.Cancel();
+
+            #if NET6_0_OR_GREATER
             await Assert.ThrowsAsync<TaskCanceledException>(
                 async () => await FirebaseMessaging.DefaultInstance.SendAsync(
                     new Message() { Topic = "test-topic" }, canceller.Token));
+            #else
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                async () => await FirebaseMessaging.DefaultInstance.SendAsync(
+                    new Message() { Topic = "test-topic" }, canceller.Token));
+            #endif
         }
 
         [Fact]

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingTest.cs
@@ -99,7 +99,7 @@ namespace FirebaseAdmin.Messaging.Tests
             FirebaseApp.Create(new AppOptions() { Credential = MockCredential });
             var canceller = new CancellationTokenSource();
             canceller.Cancel();
-            await Assert.ThrowsAsync<OperationCanceledException>(
+            await Assert.ThrowsAsync<TaskCanceledException>(
                 async () => await FirebaseMessaging.DefaultInstance.SendAsync(
                     new Message() { Topic = "test-topic" }, canceller.Token));
         }
@@ -114,7 +114,7 @@ namespace FirebaseAdmin.Messaging.Tests
             });
             var canceller = new CancellationTokenSource();
             canceller.Cancel();
-            await Assert.ThrowsAsync<OperationCanceledException>(
+            await Assert.ThrowsAsync<TaskCanceledException>(
                 async () => await FirebaseMessaging.DefaultInstance.SendAsync(
                     new Message() { Topic = "test-topic" }, canceller.Token));
         }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -339,10 +339,10 @@ namespace FirebaseAdmin.Messaging.Tests
                                             "color", new JObject()
                                             {
                                                 { "red", 0.6666667 },
-                                                #if NET6_0_OR_GREATER
-                                                { "green", 0.73333335 },
-                                                #else
+                                                #if NETCOREAPP3_1
                                                 { "green", 0.733333349 },
+                                                #else
+                                                { "green", 0.73333335 },
                                                 #endif
                                                 { "blue", 0.8 },
                                                 { "alpha", 0.8666667 },

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -339,7 +339,7 @@ namespace FirebaseAdmin.Messaging.Tests
                                             "color", new JObject()
                                             {
                                                 { "red", 0.6666667 },
-                                                { "green", 0.733333349 },
+                                                { "green", 0.73333335 },
                                                 { "blue", 0.8 },
                                                 { "alpha", 0.8666667 },
                                             }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -339,7 +339,7 @@ namespace FirebaseAdmin.Messaging.Tests
                                             "color", new JObject()
                                             {
                                                 { "red", 0.6666667 },
-                                                #if NETCOREAPP3_1
+                                                #if NET462_OR_GREATER
                                                 { "green", 0.733333349 },
                                                 #else
                                                 { "green", 0.73333335 },

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -339,7 +339,11 @@ namespace FirebaseAdmin.Messaging.Tests
                                             "color", new JObject()
                                             {
                                                 { "red", 0.6666667 },
+                                                #if NET6_0_OR_GREATER
                                                 { "green", 0.73333335 },
+                                                #else
+                                                { "green", 0.733333349 },
+                                                #endif
                                                 { "blue", 0.8 },
                                                 { "alpha", 0.8666667 },
                                             }

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -339,10 +339,10 @@ namespace FirebaseAdmin.Messaging.Tests
                                             "color", new JObject()
                                             {
                                                 { "red", 0.6666667 },
-                                                #if NET462_OR_GREATER
-                                                { "green", 0.733333349 },
-                                                #else
+                                                #if NET6_0_OR_GREATER
                                                 { "green", 0.73333335 },
+                                                #else
+                                                { "green", 0.733333349 },
                                                 #endif
                                                 { "blue", 0.8 },
                                                 { "alpha", 0.8666667 },

--- a/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>2.4.0</Version>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>

--- a/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>2.4.0</Version>
-    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>

--- a/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>2.4.0</Version>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net462;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../FirebaseAdmin.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
- Dropped `net461` support
- Added `net462` and `net6.0`+ support