### PR TITLE
(chore): Marked net 4.6.1 as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,13 @@ We also welcome bug reports, feature requests, and code review feedback.
 
 Admin .NET SDK supports the following frameworks:
 
-* .NET Framework 4.6.1+
+* .NET Framework 4.6.1+ (4.6.2+ recommended)
 * .NET Standard 2.0, providing .NET Core support
+
+Support for .NET Framework 4.6.1 is now deprecated.
+Next major version of the Admin SDK will terminate support for this
+framework. Developers are advised to upgrade their runtime frameworks
+accordingly.
 
 This is consistent with the frameworks supported by other .NET libraries
 associated with Google Cloud Platform.


### PR DESCRIPTION
Support for .NET Framework 4.6.1 is now deprecated.

Next major version of the Admin SDK will terminate support for this
framework. Developers are advised to upgrade their runtime frameworks
accordingly.