### PR TITLE
chore: fix dependabot .NET path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: "nuget"
-    directory: "/"
+    directory: "/FirebaseAdmin"
     schedule:
       interval: "weekly"
 


### PR DESCRIPTION
Should now point to `FirebaseAdmin/FirebaseAdmin.sln` which has references to each of the nested `*.csproj` file.