### PR TITLE
(chore): Bump `upload-artifact` and `download-artifact` to v4

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,7 +66,7 @@ jobs:
     # Attach the packaged artifacts to the workflow output. These can be manually
     # downloaded for later inspection if necessary.
     - name: Archive artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: Release
         path: FirebaseAdmin/FirebaseAdmin/bin/Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
     # Attach the packaged artifacts to the workflow output. These can be manually
     # downloaded for later inspection if necessary.
     - name: Archive artifacts
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: Release
         path: FirebaseAdmin/FirebaseAdmin/bin/Release
@@ -105,7 +105,7 @@ jobs:
 
     # Download the artifacts created by the stage_release job.
     - name: Download release candidates
-      uses: actions/download-artifact@v1
+      uses: actions/download-artifact@v4
       with:
         name: Release
 


### PR DESCRIPTION
Starting November 30, 2024, GitHub Actions customers will no longer be able to use v1 to v3 of actions/upload-artifact or actions/download-artifact.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/