### PR TITLE
[chore] Release 3.0.0 Take 2

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
+++ b/FirebaseAdmin/FirebaseAdmin/FirebaseAdmin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>2.4.1</Version>
+    <Version>3.0.0</Version>
     <TargetFrameworks>netstandard2.0;net462;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Dropped support for .NET Framework 4.6.1. Developers are now required to use .NET Framework 4.6.2+ or .NET 6.0+

