### PR TITLE
chore: Add mono install step to GHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,15 +20,15 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
-    - name: Install Mono
-      run: |
-        sudo apt update
-        sudo apt install -y mono-complete
-
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.x
+
+    - name: Install Mono
+      run: |
+        sudo apt update
+        sudo apt install -y mono-complete
 
     - name: Install dependencies
       run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Install Mono
+      run: |
+        sudo apt update
+        sudo apt install -y mono-complete
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         dotnet-version: 6.0.x
 
     - name: Install Mono
+      if: matrix.framework-version == 'net462'
       run: |
         sudo apt update
         sudo apt install -y mono-complete

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,6 +44,11 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
+    - name: Install Mono
+      run: |
+        sudo apt update
+        sudo apt install -y mono-complete
+
     - name: Install dependencies
       run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
       with:
         dotnet-version: 6.0.x
 
+    - name: Install Mono
+      run: |
+        sudo apt update
+        sudo apt install -y mono-complete
+
     - name: Install dependencies
       run: dotnet restore FirebaseAdmin/FirebaseAdmin.sln
 


### PR DESCRIPTION
Ubuntu 24.04 requires mono to be installed in order to run tests in net462.