### PR TITLE
fix(auth): Fixed auth error code parsing

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractFirebaseAuthTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/Auth/AbstractFirebaseAuthTest.cs
@@ -36,6 +36,13 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             HandleCodeInApp = false,
         };
 
+        private static readonly ActionCodeSettings InvalidEmailLinkSettingsWithCustomDomain = new ActionCodeSettings()
+        {
+            Url = ContinueUrl,
+            HandleCodeInApp = true,
+            LinkDomain = "cool.link.domain",
+        };
+
         private readonly AbstractAuthFixture<T> fixture;
         private readonly TemporaryUserBuilder userBuilder;
 
@@ -656,6 +663,18 @@ namespace FirebaseAdmin.IntegrationTests.Auth
             // Sign in with link also verifies the user's email
             user = await this.Auth.GetUserAsync(user.Uid);
             Assert.True(user.EmailVerified);
+        }
+
+        [Fact]
+        public async Task AuthErrorCodeParse()
+        {
+            var user = await this.userBuilder.CreateRandomUserAsync();
+
+            var exception = await Assert.ThrowsAsync<FirebaseAuthException>(
+                () => this.Auth.GeneratePasswordResetLinkAsync(
+                    user.Email, InvalidEmailLinkSettingsWithCustomDomain));
+            Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
+            Assert.Equal(AuthErrorCode.InvalidHostingLinkDomain, exception.AuthErrorCode);
         }
 
         private async Task<FirebaseToken> AssertValidIdTokenAsync(

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthErrorHandlerTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Auth/AuthErrorHandlerTest.cs
@@ -115,6 +115,31 @@ namespace FirebaseAdmin.Auth.Tests
             Assert.EndsWith($" ({code}): Some details.", error.Message);
         }
 
+        [Theory]
+        [MemberData(nameof(AuthErrorCodes))]
+        public void KnownErrorCodeWithDetailsAndWhiteSpace(
+            string code, ErrorCode expectedCode, AuthErrorCode expectedAuthCode)
+        {
+            var json = $@"{{
+                ""error"": {{
+                    ""message"": ""{code} : Some details. "",
+                }}
+            }}";
+            var resp = new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.ServiceUnavailable,
+                Content = new StringContent(json, Encoding.UTF8, "application/json"),
+            };
+
+            var error = AuthErrorHandler.Instance.HandleHttpErrorResponse(resp, json);
+
+            Assert.Equal(expectedCode, error.ErrorCode);
+            Assert.Equal(expectedAuthCode, error.AuthErrorCode);
+            Assert.Same(resp, error.HttpResponse);
+            Assert.Null(error.InnerException);
+            Assert.EndsWith($" ({code}): Some details.", error.Message);
+        }
+
         [Fact]
         public void UnknownErrorCode()
         {

--- a/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorHandler.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Auth/AuthErrorHandler.cs
@@ -209,7 +209,8 @@ namespace FirebaseAdmin.Auth
 
             /// <summary>
             /// Gets the Firebase Auth error code extracted from the response. Returns empty string
-            /// if the error code cannot be determined.
+            /// if the error code cannot be determined. These error messages take the form
+            /// <c>{"error": {"message": "CODE : OPTIONAL DETAILS"}}</c>.
             /// </summary>
             internal string Code
             {
@@ -218,7 +219,7 @@ namespace FirebaseAdmin.Auth
                     var separator = this.GetSeparator();
                     if (separator != -1)
                     {
-                        return this.Message.Substring(0, separator);
+                        return this.Message.Substring(0, separator).Trim();
                     }
 
                     return this.Message ?? string.Empty;


### PR DESCRIPTION
The auth error code parser incorrectly mapped known error codes to unknown errors due to additional whitespace from the expected auth error message. This whitespace is now trimmed and correctly mapped to the corresponding auth error code.