### PR TITLE
chore: Rename default branch to main

### DIFF
--- a/.github/scripts/publish_preflight_check.sh
+++ b/.github/scripts/publish_preflight_check.sh
@@ -145,8 +145,8 @@ echo_info "Generating changelog"
 echo_info "--------------------------------------------"
 echo_info ""
 
-echo_info "---< git fetch origin master --prune --unshallow >---"
-git fetch origin master --prune --unshallow
+echo_info "---< git fetch origin main --prune --unshallow >---"
+git fetch origin main --prune --unshallow
 echo ""
 
 echo_info "Generating changelog from history..."

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,7 @@ jobs:
     
     - name: Send email on failure
       if: failure()
-      uses: firebase/firebase-admin-node/.github/actions/send-email@master
+      uses: firebase/firebase-admin-node/.github/actions/send-email@main
       with:
         api-key: ${{ secrets.OSS_BOT_MAILGUN_KEY }}
         domain: ${{ secrets.OSS_BOT_MAILGUN_DOMAIN }}
@@ -93,7 +93,7 @@ jobs:
 
     - name: Send email on cancelled
       if: cancelled()
-      uses: firebase/firebase-admin-node/.github/actions/send-email@master
+      uses: firebase/firebase-admin-node/.github/actions/send-email@main
       with:
         api-key: ${{ secrets.OSS_BOT_MAILGUN_KEY }}
         domain: ${{ secrets.OSS_BOT_MAILGUN_DOMAIN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,11 +92,11 @@ jobs:
 
     # Check whether the release should be published. We publish only when the trigger PR is
     #   1. merged
-    #   2. to the master branch
+    #   2. to the main branch
     #   3. with the label 'release:publish', and
     #   4. the title prefix '[chore] Release '.
     if: github.event.pull_request.merged &&
-      github.ref == 'refs/heads/master' &&
+      github.ref == 'refs/heads/main' &&
       contains(github.event.pull_request.labels.*.name, 'release:publish') &&
       startsWith(github.event.pull_request.title, '[chore] Release ')
 
@@ -145,7 +145,7 @@ jobs:
     - name: Post to Twitter
       if: success() &&
         contains(github.event.pull_request.labels.*.name, 'release:tweet')
-      uses: firebase/firebase-admin-node/.github/actions/send-tweet@master
+      uses: firebase/firebase-admin-node/.github/actions/send-tweet@main
       with:
         status: >
           ${{ steps.preflight.outputs.version }} of @Firebase Admin .NET SDK is available.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Great, we love hearing how we can improve our products! Share you idea through o
 
 Sweet, we'd love to accept your contribution! In fact this project is mainly
 driven by contributions from our community.
-[Open a new pull request](https://github.com/firebase/firebase-admin-dotnet/pull/new/master) and fill
+[Open a new pull request](https://github.com/firebase/firebase-admin-dotnet/pull/new) and fill
 out the provided template.
 
 **If you want to implement a new feature, please open an issue with a proposal first so that we can

--- a/prepare_release.sh
+++ b/prepare_release.sh
@@ -106,10 +106,10 @@ fi
 #  VALIDATE REPO  #
 ###################
 
-# Ensure the checked out branch is master
+# Ensure the checked out branch is main
 CHECKED_OUT_BRANCH="$(git branch | grep "*" | awk -F ' ' '{print $2}')"
-if [[ $CHECKED_OUT_BRANCH != "master" ]]; then
-    read -p "[WARN] You are on the '${CHECKED_OUT_BRANCH}' branch, not 'master'. Continue? (y/N) " CONTINUE
+if [[ $CHECKED_OUT_BRANCH != "main" ]]; then
+    read -p "[WARN] You are on the '${CHECKED_OUT_BRANCH}' branch, not 'main'. Continue? (y/N) " CONTINUE
     case $CONTINUE in
         y|Y) ;;
         *) echo "[INFO] You chose not to continue." ;


### PR DESCRIPTION
Updated default branch name to main

If you have a local clone, you can update it by running the following commands:
```
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

Optionally, run the following command to remove tracking references to the old branch name.
```
git remote prune origin
```