### PR TITLE
chore: Enable NuGet trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,18 +152,3 @@ jobs:
       env:
         NUGET_KEY: ${{ steps.nuget_login.outputs.NUGET_API_KEY }}
         VERSION: ${{ steps.preflight.outputs.version }}
-
-    # Post to Twitter if explicitly opted-in by adding the label 'release:tweet'.
-    - name: Post to Twitter
-      if: success() &&
-        contains(github.event.pull_request.labels.*.name, 'release:tweet')
-      uses: firebase/firebase-admin-node/.github/actions/send-tweet@2e2b36a84ba28679bcb7aecdacabfec0bded2d48 # Admin Node SDK v13.6.0
-      with:
-        status: >
-          ${{ steps.preflight.outputs.version }} of @Firebase Admin .NET SDK is available.
-          https://github.com/firebase/firebase-admin-dotnet/releases/tag/${{ steps.preflight.outputs.version }}
-        consumer-key: ${{ secrets.TWITTER_CONSUMER_KEY }}
-        consumer-secret: ${{ secrets.TWITTER_CONSUMER_SECRET }}
-        access-token: ${{ secrets.TWITTER_ACCESS_TOKEN }}
-        access-token-secret: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
-      continue-on-error: true


### PR DESCRIPTION
See: https://learn.microsoft.com/en-us/nuget/nuget-org/trusted-publishing

Also removed unused release tweet action.