### PR TITLE
feat(fcm): Add support for bandwidth constrained and restricted satellite APIs

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
@@ -46,6 +46,8 @@ namespace FirebaseAdmin.IntegrationTests
                     TimeToLive = TimeSpan.FromHours(1),
                     RestrictedPackageName = "com.google.firebase.testing",
                     DirectBootOk = true,
+                    BandwidthConstrainedOk = true,
+                    RestrictedSatelliteOk = true,
                 },
             };
             var id = await FirebaseMessaging.DefaultInstance.SendAsync(message, dryRun: true);
@@ -71,6 +73,8 @@ namespace FirebaseAdmin.IntegrationTests
                     TimeToLive = TimeSpan.FromHours(1),
                     RestrictedPackageName = "com.google.firebase.testing",
                     DirectBootOk = false,
+                    BandwidthConstrainedOk = false,
+                    RestrictedSatelliteOk = false,
                 },
             };
             var message2 = new Message()
@@ -87,6 +91,8 @@ namespace FirebaseAdmin.IntegrationTests
                     TimeToLive = TimeSpan.FromHours(1),
                     RestrictedPackageName = "com.google.firebase.testing",
                     DirectBootOk = true,
+                    BandwidthConstrainedOk = true,
+                    RestrictedSatelliteOk = true,
                 },
             };
             var response = await FirebaseMessaging.DefaultInstance.SendEachAsync(new[] { message1, message2 }, dryRun: true);

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -261,6 +261,8 @@ namespace FirebaseAdmin.Messaging.Tests
                         { "k2", "v2" },
                     },
                     DirectBootOk = true,
+                    BandwidthConstrainedOk = true,
+                    RestrictedSatelliteOk = true,
                     Notification = new AndroidNotification()
                     {
                         Title = "title",
@@ -313,6 +315,8 @@ namespace FirebaseAdmin.Messaging.Tests
                         { "restricted_package_name", "test-pkg-name" },
                         { "data", new JObject() { { "k1", "v1" }, { "k2", "v2" } } },
                         { "direct_boot_ok", true },
+                        { "bandwidth_constrained_ok", true },
+                        { "restricted_satellite_ok", true },
                         {
                             "notification", new JObject()
                             {
@@ -429,6 +433,8 @@ namespace FirebaseAdmin.Messaging.Tests
                     { "key", "value" },
                 },
                 DirectBootOk = false,
+                BandwidthConstrainedOk = true,
+                RestrictedSatelliteOk = false,
                 Notification = new AndroidNotification()
                 {
                     Title = "title",
@@ -443,6 +449,8 @@ namespace FirebaseAdmin.Messaging.Tests
             Assert.Equal(original.TimeToLive, copy.TimeToLive);
             Assert.Equal(original.Data, copy.Data);
             Assert.Equal(original.DirectBootOk, copy.DirectBootOk);
+            Assert.Equal(original.BandwidthConstrainedOk, copy.BandwidthConstrainedOk);
+            Assert.Equal(original.RestrictedSatelliteOk, copy.RestrictedSatelliteOk);
             Assert.Equal(original.Notification.Title, copy.Notification.Title);
         }
 

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidConfig.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/AndroidConfig.cs
@@ -68,6 +68,20 @@ namespace FirebaseAdmin.Messaging
         public bool? DirectBootOk { get; set; }
 
         /// <summary>
+        /// Gets or sets a boolean indicating whether messages will be allowed to be delivered to
+        /// the app while the device is on a bandwidth constrained network.
+        /// </summary>
+        [JsonProperty("bandwidth_constrained_ok")]
+        public bool? BandwidthConstrainedOk { get; set; }
+
+        /// <summary>
+        /// Gets or sets a boolean indicating whether messages will be allowed to be delivered to
+        /// the app while the device is on a restricted satellite network.
+        /// </summary>
+        [JsonProperty("restricted_satellite_ok")]
+        public bool? RestrictedSatelliteOk { get; set; }
+
+        /// <summary>
         /// Gets or sets the Android notification to be included in the message.
         /// </summary>
         [JsonProperty("notification")]
@@ -173,6 +187,8 @@ namespace FirebaseAdmin.Messaging
                 RestrictedPackageName = this.RestrictedPackageName,
                 Data = this.Data?.Copy(),
                 DirectBootOk = this.DirectBootOk,
+                BandwidthConstrainedOk = this.BandwidthConstrainedOk,
+                RestrictedSatelliteOk = this.RestrictedSatelliteOk,
                 FcmOptions = this.FcmOptions?.CopyAndValidate(),
             };
             var totalSeconds = copy.TimeToLive?.TotalSeconds ?? 0;


### PR DESCRIPTION
This change introduces the `BandwidthConstrainedOk` and `RestrictedSatelliteOk` properties to the `AndroidConfig` object to give developers more granular control over message delivery in resource-constrained environments. By configuring these options, developers can explicitly specify whether a notification should be allowed to be delivered when the receiving device is in a bandwidth-constrained state or when it is connected via a restricted satellite network.