### PR TITLE
feat(fcm): Enable `fid` and deprecate `token` for Send API

### DIFF
--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
@@ -120,11 +120,13 @@ namespace FirebaseAdmin.IntegrationTests
                     TimeToLive = TimeSpan.FromHours(1),
                     RestrictedPackageName = "com.google.firebase.testing",
                 },
+#pragma warning disable CS0618
                 Tokens = new[]
                 {
                     "token1",
                     "token2",
                 },
+#pragma warning restore CS0618
             };
             var response = await FirebaseMessaging.DefaultInstance.SendEachForMulticastAsync(multicastMessage, dryRun: true);
             Assert.NotNull(response);

--- a/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.IntegrationTests/FirebaseMessagingTest.cs
@@ -136,6 +136,35 @@ namespace FirebaseAdmin.IntegrationTests
         }
 
         [Fact]
+        public async Task SendEachForMulticastFids()
+        {
+            var multicastMessage = new MulticastMessage
+            {
+                Notification = new Notification()
+                {
+                    Title = "Title",
+                    Body = "Body",
+                },
+                Android = new AndroidConfig()
+                {
+                    Priority = Priority.Normal,
+                    TimeToLive = TimeSpan.FromHours(1),
+                    RestrictedPackageName = "com.google.firebase.testing",
+                },
+                Fids = new[]
+                {
+                    "fid1",
+                    "fid2",
+                },
+            };
+            var response = await FirebaseMessaging.DefaultInstance.SendEachForMulticastAsync(multicastMessage, dryRun: true);
+            Assert.NotNull(response);
+            Assert.Equal(2, response.FailureCount);
+            Assert.Equal(MessagingErrorCode.Unregistered, response.Responses[0].Exception.MessagingErrorCode);
+            Assert.Equal(MessagingErrorCode.Unregistered, response.Responses[1].Exception.MessagingErrorCode);
+        }
+
+        [Fact]
         public async Task SubscribeToTopic()
         {
             var response = await FirebaseMessaging.DefaultInstance.SubscribeToTopicAsync(

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseExceptionSnippets.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseExceptionSnippets.cs
@@ -139,7 +139,9 @@ namespace FirebaseAdmin.Snippets
         {
             return new Message()
             {
+#pragma warning disable CS0618
                 Token = deviceToken,
+#pragma warning restore CS0618
                 Notification = new Notification()
                 {
                     Title = "Test notification",

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseExceptionSnippets.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseExceptionSnippets.cs
@@ -102,6 +102,40 @@ namespace FirebaseAdmin.Snippets
             // [END platform_error_code]
         }
 
+        internal static async Task PlatformErrorCodeWithFid(string fid)
+        {
+            // [START platform_error_code_fid]
+            var notification = CreateNotificationWithFid(fid);
+            try
+            {
+                await FirebaseMessaging.DefaultInstance.SendAsync(notification);
+            }
+            catch (FirebaseMessagingException ex)
+            {
+                // All exceptions contain a platform-level error code. Applications can inspect
+                // both the platform-level error code and any service-level error codes when
+                // implementing error handling logic.
+                if (ex.MessagingErrorCode == MessagingErrorCode.Unregistered)
+                {
+                    // Service-level error code
+                    Console.WriteLine("App instance has been unregistered");
+                    RemoveFidFromDatabase(fid);
+                }
+                else if (ex.ErrorCode == ErrorCode.Unavailable)
+                {
+                    // Platform-level error code
+                    Console.WriteLine("FCM service is temporarily unavailable");
+                    ScheduleForRetry(notification, TimeSpan.FromHours(1));
+                }
+                else
+                {
+                    Console.WriteLine($"Failed to send notification: {ex.Message}");
+                }
+            }
+
+            // [END platform_error_code_fid]
+        }
+
         internal static async Task HttpResponse(string deviceToken)
         {
             // [START http_response]
@@ -133,6 +167,37 @@ namespace FirebaseAdmin.Snippets
             // [END http_response]
         }
 
+        internal static async Task HttpResponseWithFid(string fid)
+        {
+            // [START http_response_fid]
+            var notification = CreateNotificationWithFid(fid);
+            try
+            {
+                await FirebaseMessaging.DefaultInstance.SendAsync(notification);
+            }
+            catch (FirebaseMessagingException ex)
+            {
+                // If the exception was caused by a backend service error, applications can
+                // inspect the original error response received from the backend service to
+                // implement more advanced error handling behavior.
+                var response = ex.HttpResponse;
+                if (response != null)
+                {
+                    Console.WriteLine($"FCM service responded with HTTP {response.StatusCode}");
+                    foreach (var entry in response.Headers)
+                    {
+                        Console.WriteLine($">>> {entry.Key}: {entry.Value}");
+                    }
+
+                    var body = await response.Content.ReadAsStringAsync();
+                    Console.WriteLine(">>>");
+                    Console.WriteLine($">>> {body}");
+                }
+            }
+
+            // [END http_response_fid]
+        }
+
         private static void PerformPrivilegedOperation(string uid) { }
 
         private static Message CreateNotification(string deviceToken)
@@ -149,7 +214,21 @@ namespace FirebaseAdmin.Snippets
             };
         }
 
+        private static Message CreateNotificationWithFid(string fid)
+        {
+            return new Message()
+            {
+                Fid = fid,
+                Notification = new Notification()
+                {
+                    Title = "Test notification",
+                },
+            };
+        }
+
         private static void RemoveTokenFromDatabase(string deviceToken) { }
+
+        private static void RemoveFidFromDatabase(string fid) { }
 
         private static void ScheduleForRetry(Message message, TimeSpan waitTime) { }
     }

--- a/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseMessagingSnippets.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Snippets/FirebaseMessagingSnippets.cs
@@ -35,7 +35,9 @@ namespace FirebaseAdmin.Snippets
                     { "score", "850" },
                     { "time", "2:45" },
                 },
+#pragma warning disable CS0618
                 Token = registrationToken,
+#pragma warning restore CS0618
             };
 
             // Send a message to the device corresponding to the provided
@@ -105,7 +107,9 @@ namespace FirebaseAdmin.Snippets
                     { "score", "850" },
                     { "time", "2:45" },
                 },
+#pragma warning disable CS0618
                 Token = "token",
+#pragma warning restore CS0618
             };
 
             // [START send_dry_run]
@@ -131,7 +135,9 @@ namespace FirebaseAdmin.Snippets
                         Title = "Price drop",
                         Body = "5% off all electronics",
                     },
+#pragma warning disable CS0618
                     Token = registrationToken,
+#pragma warning restore CS0618
                 },
                 new Message()
                 {
@@ -164,7 +170,9 @@ namespace FirebaseAdmin.Snippets
             };
             var message = new MulticastMessage()
             {
+#pragma warning disable CS0618
                 Tokens = registrationTokens,
+#pragma warning restore CS0618
                 Data = new Dictionary<string, string>()
                 {
                     { "score", "850" },
@@ -191,7 +199,9 @@ namespace FirebaseAdmin.Snippets
             };
             var message = new MulticastMessage()
             {
+#pragma warning disable CS0618
                 Tokens = registrationTokens,
+#pragma warning restore CS0618
                 Data = new Dictionary<string, string>()
                 {
                     { "score", "850" },

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
@@ -250,6 +250,83 @@ namespace FirebaseAdmin.Messaging.Tests
         }
 
         [Fact]
+        public async Task SendEachAsyncWithTokenError()
+        {
+            // Return a success for `message1` and an error for `message2`
+            var handler = new MockMessageHandler()
+            {
+                GenerateResponse = (incomingRequest) =>
+                {
+                    string name;
+                    if (incomingRequest.Body.Contains("test-token1"))
+                    {
+                        name = "projects/fir-adminintegrationtests/messages/8580920590356323124";
+                        return new FirebaseMessagingClient.SingleMessageResponse()
+                        {
+                            Name = name,
+                        };
+                    }
+                    else
+                    {
+                        return @"{
+                                    ""error"": {
+                                        ""status"": ""INVALID_ARGUMENT"",
+                                        ""message"": ""The registration token is not a valid FCM registration token"",
+                                        ""details"": [
+                                            {
+                                                ""@type"": ""type.googleapis.com/google.firebase.fcm.v1.FcmError"",
+                                                ""errorCode"": ""UNREGISTERED""
+                                            }
+                                        ]
+                                    }
+                                }";
+                    }
+                },
+                GenerateStatusCode = (incomingRequest) =>
+                {
+                    if (incomingRequest.Body.Contains("test-token1"))
+                    {
+                        return HttpStatusCode.OK;
+                    }
+                    else
+                    {
+                        return HttpStatusCode.BadRequest;
+                    }
+                },
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var client = this.CreateMessagingClient(factory);
+            var message1 = new Message()
+            {
+#pragma warning disable CS0618
+                Token = "test-token1",
+#pragma warning restore CS0618,
+            };
+            var message2 = new Message()
+            {
+#pragma warning disable CS0618
+                Token = "test-token2",
+#pragma warning restore CS0618,
+            };
+
+            var response = await client.SendEachAsync(new[] { message1, message2 });
+
+            Assert.Equal(1, response.SuccessCount);
+            Assert.Equal(1, response.FailureCount);
+            Assert.Equal("projects/fir-adminintegrationtests/messages/8580920590356323124", response.Responses[0].MessageId);
+
+            var exception = response.Responses[1].Exception;
+            Assert.NotNull(exception);
+            Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
+            Assert.Equal("The registration token is not a valid FCM registration token", exception.Message);
+            Assert.Equal(MessagingErrorCode.Unregistered, exception.MessagingErrorCode);
+            Assert.NotNull(exception.HttpResponse);
+
+            Assert.Equal(2, handler.Calls);
+            this.CheckHeaders(handler.LastRequestHeaders);
+        }
+
+        [Fact]
         public async Task SendEachAsyncWithErrorNoDetail()
         {
             // Return a success for `message1` and an error for `message2`
@@ -309,6 +386,77 @@ namespace FirebaseAdmin.Messaging.Tests
             Assert.NotNull(exception);
             Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
             Assert.Equal("Requested entity was not found.", exception.Message);
+            Assert.Null(exception.MessagingErrorCode);
+            Assert.NotNull(exception.HttpResponse);
+
+            Assert.Equal(2, handler.Calls);
+            this.CheckHeaders(handler.LastRequestHeaders);
+        }
+
+        [Fact]
+        public async Task SendEachAsyncWithTokenErrorNoDetail()
+        {
+            // Return a success for `message1` and an error for `message2`
+            var handler = new MockMessageHandler()
+            {
+                GenerateResponse = (incomingRequest) =>
+                {
+                    string name;
+                    if (incomingRequest.Body.Contains("test-token1"))
+                    {
+                        name = "projects/fir-adminintegrationtests/messages/8580920590356323124";
+                        return new FirebaseMessagingClient.SingleMessageResponse()
+                        {
+                            Name = name,
+                        };
+                    }
+                    else
+                    {
+                        return @"{
+                                    ""error"": {
+                                        ""status"": ""INVALID_ARGUMENT"",
+                                        ""message"": ""The registration token is not a valid FCM registration token"",
+                                    }
+                                }";
+                    }
+                },
+                GenerateStatusCode = (incomingRequest) =>
+                {
+                    if (incomingRequest.Body.Contains("test-token1"))
+                    {
+                        return HttpStatusCode.OK;
+                    }
+                    else
+                    {
+                        return HttpStatusCode.BadRequest;
+                    }
+                },
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var client = this.CreateMessagingClient(factory);
+            var message1 = new Message()
+            {
+#pragma warning disable CS0618
+                Token = "test-token1",
+#pragma warning restore CS0618,
+            };
+            var message2 = new Message()
+            {
+#pragma warning disable CS0618
+                Token = "test-token2",
+#pragma warning restore CS0618,
+            };
+
+            var response = await client.SendEachAsync(new[] { message1, message2 });
+
+            Assert.Equal(1, response.SuccessCount);
+            Assert.Equal(1, response.FailureCount);
+            Assert.Equal("projects/fir-adminintegrationtests/messages/8580920590356323124", response.Responses[0].MessageId);
+
+            var exception = response.Responses[1].Exception;
+            Assert.NotNull(exception);
+            Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
+            Assert.Equal("The registration token is not a valid FCM registration token", exception.Message);
             Assert.Null(exception.MessagingErrorCode);
             Assert.NotNull(exception.HttpResponse);
 
@@ -494,6 +642,93 @@ Vary: Referer
         }
 
         [Fact]
+        public async Task SendAllAsyncWithTokenError()
+        {
+            var rawResponse = @"
+--batch_test-boundary
+Content-Type: application/http
+Content-ID: response-
+
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+
+{
+  ""name"": ""projects/fir-adminintegrationtests/messages/8580920590356323124""
+}
+
+--batch_test-boundary
+Content-Type: application/http
+Content-ID: response-
+
+HTTP/1.1 400 Bad Request
+Content-Type: application/json; charset=UTF-8
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+
+{
+  ""error"": {
+    ""code"": 404,
+    ""message"": ""The registration token is not a valid FCM registration token"",
+    ""details"": [
+        {
+            ""@type"": ""type.googleapis.com/google.firebase.fcm.v1.FcmError"",
+            ""errorCode"": ""UNREGISTERED""
+        }
+    ],
+    ""status"": ""INVALID_ARGUMENT""
+  }
+}
+
+--batch_test-boundary
+";
+            var handler = new MockMessageHandler()
+            {
+                Response = rawResponse,
+                ApplyHeaders = (_, headers) =>
+                {
+                    headers.Remove("Content-Type");
+                    headers.TryAddWithoutValidation("Content-Type", "multipart/mixed; boundary=batch_test-boundary");
+                },
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var client = this.CreateMessagingClient(factory);
+            var message1 = new Message()
+            {
+#pragma warning disable CS0618
+                Token = "test-token1",
+#pragma warning restore CS0618,
+            };
+            var message2 = new Message()
+            {
+#pragma warning disable CS0618
+                Token = "test-token2",
+#pragma warning restore CS0618,
+            };
+
+            var response = await client.SendAllAsync(new[] { message1, message2 });
+
+            Assert.Equal(1, response.SuccessCount);
+            Assert.Equal(1, response.FailureCount);
+            Assert.Equal("projects/fir-adminintegrationtests/messages/8580920590356323124", response.Responses[0].MessageId);
+
+            var exception = response.Responses[1].Exception;
+            Assert.NotNull(exception);
+            Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
+            Assert.Equal("The registration token is not a valid FCM registration token", exception.Message);
+            Assert.Equal(MessagingErrorCode.Unregistered, exception.MessagingErrorCode);
+            Assert.NotNull(exception.HttpResponse);
+
+            Assert.Equal(1, handler.Calls);
+            Assert.Equal(2, this.CountLinesWithPrefix(handler.LastRequestBody, VersionHeader));
+            Assert.Equal(2, this.CountLinesWithPrefix(handler.LastRequestBody, ApiFormatHeader));
+            Assert.Equal(2, this.CountLinesWithPrefix(handler.LastRequestBody, $"X-Goog-Api-Client: {HttpUtils.GetMetricsHeader()}"));
+        }
+
+        [Fact]
         public async Task SendAllAsyncWithErrorNoDetail()
         {
             var rawResponse = @"
@@ -563,6 +798,89 @@ Content-Type: application/json; charset=UTF-8
             Assert.NotNull(exception);
             Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
             Assert.Equal("Requested entity was not found.", exception.Message);
+            Assert.Null(exception.MessagingErrorCode);
+            Assert.NotNull(exception.HttpResponse);
+
+            Assert.Equal(1, handler.Calls);
+            Assert.Equal(2, this.CountLinesWithPrefix(handler.LastRequestBody, VersionHeader));
+            Assert.Equal(2, this.CountLinesWithPrefix(handler.LastRequestBody, ApiFormatHeader));
+            Assert.Equal(2, this.CountLinesWithPrefix(handler.LastRequestBody, $"X-Goog-Api-Client: {HttpUtils.GetMetricsHeader()}"));
+        }
+
+        [Fact]
+        public async Task SendAllAsyncWithTokenErrorNoDetail()
+        {
+            var rawResponse = @"
+--batch_test-boundary
+Content-Type: application/http
+Content-ID: response-
+
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=UTF-8
+Vary: Origin
+Vary: X-Origin
+Vary: Referer
+
+{
+  ""name"": ""projects/fir-adminintegrationtests/messages/8580920590356323124""
+}
+
+--batch_test-boundary
+Content-Type: application/http
+Content-ID: response-
+
+HTTP/1.1 400 Bad Request
+Content-Type: application/json; charset=UTF-8
+
+{
+  ""error"": {
+    ""code"": 404,
+    ""message"": ""The registration token is not a valid FCM registration token"",
+    ""status"": ""INVALID_ARGUMENT""
+  }
+}
+
+--batch_test-boundary
+";
+            var handler = new MockMessageHandler()
+            {
+                Response = rawResponse,
+                ApplyHeaders = (_, headers) =>
+                {
+                    headers.Remove("Content-Type");
+                    headers.TryAddWithoutValidation("Content-Type", "multipart/mixed; boundary=batch_test-boundary");
+                },
+            };
+            var factory = new MockHttpClientFactory(handler);
+            var client = new FirebaseMessagingClient(new FirebaseMessagingClient.Args()
+            {
+                ClientFactory = factory,
+                Credential = MockCredential,
+                ProjectId = "test-project",
+            });
+            var message1 = new Message()
+            {
+#pragma warning disable CS0618
+                Token = "test-token1",
+#pragma warning restore CS0618,
+            };
+            var message2 = new Message()
+            {
+#pragma warning disable CS0618
+                Token = "test-token2",
+#pragma warning restore CS0618,
+            };
+
+            var response = await client.SendAllAsync(new[] { message1, message2 });
+
+            Assert.Equal(1, response.SuccessCount);
+            Assert.Equal(1, response.FailureCount);
+            Assert.Equal("projects/fir-adminintegrationtests/messages/8580920590356323124", response.Responses[0].MessageId);
+
+            var exception = response.Responses[1].Exception;
+            Assert.NotNull(exception);
+            Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
+            Assert.Equal("The registration token is not a valid FCM registration token", exception.Message);
             Assert.Null(exception.MessagingErrorCode);
             Assert.NotNull(exception.HttpResponse);
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
@@ -160,11 +160,15 @@ namespace FirebaseAdmin.Messaging.Tests
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token1",
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token2",
+#pragma warning restore CS0618
             };
 
             var response = await client.SendEachAsync(new[] { message1, message2 });
@@ -225,11 +229,15 @@ namespace FirebaseAdmin.Messaging.Tests
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token1",
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token2",
+#pragma warning restore CS0618
             };
 
             var response = await client.SendEachAsync(new[] { message1, message2 });
@@ -292,11 +300,15 @@ namespace FirebaseAdmin.Messaging.Tests
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token1",
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token2",
+#pragma warning restore CS0618
             };
 
             var response = await client.SendEachAsync(new[] { message1, message2 });
@@ -389,11 +401,15 @@ Vary: Referer
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token1",
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token2",
+#pragma warning restore CS0618
             };
 
             var response = await client.SendAllAsync(new[] { message1, message2 });
@@ -467,11 +483,15 @@ Vary: Referer
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token1",
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token2",
+#pragma warning restore CS0618
             };
 
             var response = await client.SendAllAsync(new[] { message1, message2 });
@@ -546,11 +566,15 @@ Content-Type: application/json; charset=UTF-8
             });
             var message1 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token1",
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token2",
+#pragma warning restore CS0618
             };
 
             var response = await client.SendAllAsync(new[] { message1, message2 });

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
@@ -141,7 +141,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 GenerateResponse = (incomingRequest) =>
                 {
                     string name;
-                    if (incomingRequest.Body.Contains("test-token1"))
+                    if (incomingRequest.Body.Contains("test-fid1"))
                     {
                         name = "projects/fir-adminintegrationtests/messages/8580920590356323124";
                     }
@@ -160,15 +160,11 @@ namespace FirebaseAdmin.Messaging.Tests
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token1",
-#pragma warning restore CS0618
+                Fid = "test-fid1",
             };
             var message2 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token2",
-#pragma warning restore CS0618
+                Fid = "test-fid2",
             };
 
             var response = await client.SendEachAsync(new[] { message1, message2 });
@@ -189,7 +185,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 GenerateResponse = (incomingRequest) =>
                 {
                     string name;
-                    if (incomingRequest.Body.Contains("test-token1"))
+                    if (incomingRequest.Body.Contains("test-fid1"))
                     {
                         name = "projects/fir-adminintegrationtests/messages/8580920590356323124";
                         return new FirebaseMessagingClient.SingleMessageResponse()
@@ -201,8 +197,8 @@ namespace FirebaseAdmin.Messaging.Tests
                     {
                         return @"{
                                     ""error"": {
-                                        ""status"": ""INVALID_ARGUMENT"",
-                                        ""message"": ""The registration token is not a valid FCM registration token"",
+                                        ""status"": ""NOT_FOUND"",
+                                        ""message"": ""Requested entity was not found."",
                                         ""details"": [
                                             {
                                                 ""@type"": ""type.googleapis.com/google.firebase.fcm.v1.FcmError"",
@@ -215,13 +211,13 @@ namespace FirebaseAdmin.Messaging.Tests
                 },
                 GenerateStatusCode = (incomingRequest) =>
                 {
-                    if (incomingRequest.Body.Contains("test-token1"))
+                    if (incomingRequest.Body.Contains("test-fid1"))
                     {
                         return HttpStatusCode.OK;
                     }
                     else
                     {
-                        return HttpStatusCode.InternalServerError;
+                        return HttpStatusCode.NotFound;
                     }
                 },
             };
@@ -229,15 +225,11 @@ namespace FirebaseAdmin.Messaging.Tests
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token1",
-#pragma warning restore CS0618
+                Fid = "test-fid1",
             };
             var message2 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token2",
-#pragma warning restore CS0618
+                Fid = "test-fid2",
             };
 
             var response = await client.SendEachAsync(new[] { message1, message2 });
@@ -248,8 +240,8 @@ namespace FirebaseAdmin.Messaging.Tests
 
             var exception = response.Responses[1].Exception;
             Assert.NotNull(exception);
-            Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
-            Assert.Equal("The registration token is not a valid FCM registration token", exception.Message);
+            Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
+            Assert.Equal("Requested entity was not found.", exception.Message);
             Assert.Equal(MessagingErrorCode.Unregistered, exception.MessagingErrorCode);
             Assert.NotNull(exception.HttpResponse);
 
@@ -266,7 +258,7 @@ namespace FirebaseAdmin.Messaging.Tests
                 GenerateResponse = (incomingRequest) =>
                 {
                     string name;
-                    if (incomingRequest.Body.Contains("test-token1"))
+                    if (incomingRequest.Body.Contains("test-fid1"))
                     {
                         name = "projects/fir-adminintegrationtests/messages/8580920590356323124";
                         return new FirebaseMessagingClient.SingleMessageResponse()
@@ -278,21 +270,21 @@ namespace FirebaseAdmin.Messaging.Tests
                     {
                         return @"{
                                     ""error"": {
-                                        ""status"": ""INVALID_ARGUMENT"",
-                                        ""message"": ""The registration token is not a valid FCM registration token"",
+                                        ""status"": ""NOT_FOUND"",
+                                        ""message"": ""Requested entity was not found."",
                                     }
                                 }";
                     }
                 },
                 GenerateStatusCode = (incomingRequest) =>
                 {
-                    if (incomingRequest.Body.Contains("test-token1"))
+                    if (incomingRequest.Body.Contains("test-fid1"))
                     {
                         return HttpStatusCode.OK;
                     }
                     else
                     {
-                        return HttpStatusCode.InternalServerError;
+                        return HttpStatusCode.NotFound;
                     }
                 },
             };
@@ -300,15 +292,11 @@ namespace FirebaseAdmin.Messaging.Tests
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token1",
-#pragma warning restore CS0618
+                Fid = "test-fid1",
             };
             var message2 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token2",
-#pragma warning restore CS0618
+                Fid = "test-fid2",
             };
 
             var response = await client.SendEachAsync(new[] { message1, message2 });
@@ -319,8 +307,8 @@ namespace FirebaseAdmin.Messaging.Tests
 
             var exception = response.Responses[1].Exception;
             Assert.NotNull(exception);
-            Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
-            Assert.Equal("The registration token is not a valid FCM registration token", exception.Message);
+            Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
+            Assert.Equal("Requested entity was not found.", exception.Message);
             Assert.Null(exception.MessagingErrorCode);
             Assert.NotNull(exception.HttpResponse);
 
@@ -401,15 +389,11 @@ Vary: Referer
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token1",
-#pragma warning restore CS0618
+                Fid = "test-fid1",
             };
             var message2 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token2",
-#pragma warning restore CS0618
+                Fid = "test-fid2",
             };
 
             var response = await client.SendAllAsync(new[] { message1, message2 });
@@ -448,7 +432,7 @@ Vary: Referer
 Content-Type: application/http
 Content-ID: response-
 
-HTTP/1.1 400 Bad Request
+HTTP/1.1 404 Not Found
 Content-Type: application/json; charset=UTF-8
 Vary: Origin
 Vary: X-Origin
@@ -456,15 +440,15 @@ Vary: Referer
 
 {
   ""error"": {
-    ""code"": 400,
-    ""message"": ""The registration token is not a valid FCM registration token"",
+    ""code"": 404,
+    ""message"": ""Requested entity was not found."",
     ""details"": [
         {
             ""@type"": ""type.googleapis.com/google.firebase.fcm.v1.FcmError"",
             ""errorCode"": ""UNREGISTERED""
         }
     ],
-    ""status"": ""INVALID_ARGUMENT""
+    ""status"": ""NOT_FOUND""
   }
 }
 
@@ -483,15 +467,11 @@ Vary: Referer
             var client = this.CreateMessagingClient(factory);
             var message1 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token1",
-#pragma warning restore CS0618
+                Fid = "test-fid1",
             };
             var message2 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token2",
-#pragma warning restore CS0618
+                Fid = "test-fid2",
             };
 
             var response = await client.SendAllAsync(new[] { message1, message2 });
@@ -502,8 +482,8 @@ Vary: Referer
 
             var exception = response.Responses[1].Exception;
             Assert.NotNull(exception);
-            Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
-            Assert.Equal("The registration token is not a valid FCM registration token", exception.Message);
+            Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
+            Assert.Equal("Requested entity was not found.", exception.Message);
             Assert.Equal(MessagingErrorCode.Unregistered, exception.MessagingErrorCode);
             Assert.NotNull(exception.HttpResponse);
 
@@ -535,14 +515,14 @@ Vary: Referer
 Content-Type: application/http
 Content-ID: response-
 
-HTTP/1.1 400 Bad Request
+HTTP/1.1 404 Not Found
 Content-Type: application/json; charset=UTF-8
 
 {
   ""error"": {
-    ""code"": 400,
-    ""message"": ""The registration token is not a valid FCM registration token"",
-    ""status"": ""INVALID_ARGUMENT""
+    ""code"": 404,
+    ""message"": ""Requested entity was not found."",
+    ""status"": ""NOT_FOUND""
   }
 }
 
@@ -566,15 +546,11 @@ Content-Type: application/json; charset=UTF-8
             });
             var message1 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token1",
-#pragma warning restore CS0618
+                Fid = "test-fid1",
             };
             var message2 = new Message()
             {
-#pragma warning disable CS0618
-                Token = "test-token2",
-#pragma warning restore CS0618
+                Fid = "test-fid2",
             };
 
             var response = await client.SendAllAsync(new[] { message1, message2 });
@@ -585,8 +561,8 @@ Content-Type: application/json; charset=UTF-8
 
             var exception = response.Responses[1].Exception;
             Assert.NotNull(exception);
-            Assert.Equal(ErrorCode.InvalidArgument, exception.ErrorCode);
-            Assert.Equal("The registration token is not a valid FCM registration token", exception.Message);
+            Assert.Equal(ErrorCode.NotFound, exception.ErrorCode);
+            Assert.Equal("Requested entity was not found.", exception.Message);
             Assert.Null(exception.MessagingErrorCode);
             Assert.NotNull(exception.HttpResponse);
 

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/FirebaseMessagingClientTest.cs
@@ -300,13 +300,13 @@ namespace FirebaseAdmin.Messaging.Tests
             {
 #pragma warning disable CS0618
                 Token = "test-token1",
-#pragma warning restore CS0618,
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
 #pragma warning disable CS0618
                 Token = "test-token2",
-#pragma warning restore CS0618,
+#pragma warning restore CS0618
             };
 
             var response = await client.SendEachAsync(new[] { message1, message2 });
@@ -438,13 +438,13 @@ namespace FirebaseAdmin.Messaging.Tests
             {
 #pragma warning disable CS0618
                 Token = "test-token1",
-#pragma warning restore CS0618,
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
 #pragma warning disable CS0618
                 Token = "test-token2",
-#pragma warning restore CS0618,
+#pragma warning restore CS0618
             };
 
             var response = await client.SendEachAsync(new[] { message1, message2 });
@@ -700,13 +700,13 @@ Vary: Referer
             {
 #pragma warning disable CS0618
                 Token = "test-token1",
-#pragma warning restore CS0618,
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
 #pragma warning disable CS0618
                 Token = "test-token2",
-#pragma warning restore CS0618,
+#pragma warning restore CS0618
             };
 
             var response = await client.SendAllAsync(new[] { message1, message2 });
@@ -862,13 +862,13 @@ Content-Type: application/json; charset=UTF-8
             {
 #pragma warning disable CS0618
                 Token = "test-token1",
-#pragma warning restore CS0618,
+#pragma warning restore CS0618
             };
             var message2 = new Message()
             {
 #pragma warning disable CS0618
                 Token = "test-token2",
-#pragma warning restore CS0618,
+#pragma warning restore CS0618
             };
 
             var response = await client.SendAllAsync(new[] { message1, message2 });

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MessageTest.cs
@@ -26,8 +26,13 @@ namespace FirebaseAdmin.Messaging.Tests
         [Fact]
         public void EmptyMessage()
         {
+#pragma warning disable CS0618
             var message = new Message() { Token = "test-token" };
+#pragma warning restore CS0618
             this.AssertJsonEquals(new JObject() { { "token", "test-token" } }, message);
+
+            message = new Message() { Fid = "test-fid" };
+            this.AssertJsonEquals(new JObject() { { "fid", "test-fid" } }, message);
 
             message = new Message() { Topic = "test-topic" };
             this.AssertJsonEquals(new JObject() { { "topic", "test-topic" } }, message);
@@ -148,6 +153,51 @@ namespace FirebaseAdmin.Messaging.Tests
         }
 
         [Fact]
+        public void MessageDeserializationWithFid()
+        {
+            var original = new Message()
+            {
+                Fid = "test-fid",
+                Data = new Dictionary<string, string>() { { "key", "value" } },
+                Notification = new Notification()
+                {
+                    Title = "title",
+                    Body = "body",
+                },
+                Android = new AndroidConfig()
+                {
+                    RestrictedPackageName = "test-pkg-name",
+                },
+                Apns = new ApnsConfig()
+                {
+                    Aps = new Aps()
+                    {
+                        AlertString = "test-alert",
+                    },
+                },
+                Webpush = new WebpushConfig()
+                {
+                    Data = new Dictionary<string, string>() { { "key", "value" } },
+                },
+                FcmOptions = new FcmOptions()
+                {
+                    AnalyticsLabel = "label",
+                },
+            };
+            var json = NewtonsoftJsonSerializer.Instance.Serialize(original);
+            var copy = NewtonsoftJsonSerializer.Instance.Deserialize<Message>(json);
+            Assert.Equal(original.Fid, copy.Fid);
+            Assert.Equal(original.Data, copy.Data);
+            Assert.Equal(original.Notification.Title, copy.Notification.Title);
+            Assert.Equal(original.Notification.Body, copy.Notification.Body);
+            Assert.Equal(
+                original.Android.RestrictedPackageName, copy.Android.RestrictedPackageName);
+            Assert.Equal(original.Apns.Aps.AlertString, copy.Apns.Aps.AlertString);
+            Assert.Equal(original.Webpush.Data, copy.Webpush.Data);
+            Assert.Equal(original.FcmOptions.AnalyticsLabel, copy.FcmOptions.AnalyticsLabel);
+        }
+
+        [Fact]
         public void MessageCopy()
         {
             var original = new Message()
@@ -169,6 +219,23 @@ namespace FirebaseAdmin.Messaging.Tests
         }
 
         [Fact]
+        public void MessageWithFidOnly()
+        {
+            var original = new Message()
+            {
+                Fid = "test-fid",
+                Data = new Dictionary<string, string>(),
+                Notification = new Notification(),
+                Android = new AndroidConfig(),
+                Apns = new ApnsConfig(),
+                Webpush = new WebpushConfig(),
+            };
+            var copy = original.CopyAndValidate();
+            Assert.NotSame(original, copy);
+            Assert.Equal("test-fid", copy.Fid);
+        }
+
+        [Fact]
         public void MessageWithoutTarget()
         {
             Assert.Throws<ArgumentException>(() => new Message().CopyAndValidate());
@@ -179,14 +246,18 @@ namespace FirebaseAdmin.Messaging.Tests
         {
             var message = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token",
+#pragma warning restore CS0618
                 Topic = "test-topic",
             };
             Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
 
             message = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token",
+#pragma warning restore CS0618
                 Condition = "test-condition",
             };
             Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
@@ -200,7 +271,43 @@ namespace FirebaseAdmin.Messaging.Tests
 
             message = new Message()
             {
+#pragma warning disable CS0618
                 Token = "test-token",
+#pragma warning restore CS0618
+                Topic = "test-topic",
+                Condition = "test-condition",
+            };
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+
+            message = new Message()
+            {
+                Fid = "test-fid",
+#pragma warning disable CS0618
+                Token = "test-token",
+#pragma warning restore CS0618
+            };
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+
+            message = new Message()
+            {
+                Fid = "test-fid",
+                Topic = "test-topic",
+            };
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+
+            message = new Message()
+            {
+                Fid = "test-fid",
+                Condition = "test-condition",
+            };
+            Assert.Throws<ArgumentException>(() => message.CopyAndValidate());
+
+            message = new Message()
+            {
+                Fid = "test-fid",
+#pragma warning disable CS0618
+                Token = "test-token",
+#pragma warning restore CS0618
                 Topic = "test-topic",
                 Condition = "test-condition",
             };

--- a/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MulticastMessageTest.cs
+++ b/FirebaseAdmin/FirebaseAdmin.Tests/Messaging/MulticastMessageTest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google Inc. All rights reserved.
+// Copyright 2018, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ namespace FirebaseAdmin.Tests.Messaging
 {
     public class MulticastMessageTest
     {
+#pragma warning disable CS0618
         [Fact]
         public void GetMessageList()
         {
@@ -35,15 +36,50 @@ namespace FirebaseAdmin.Tests.Messaging
             Assert.Equal("test-token1", messages[0].Token);
             Assert.Equal("test-token2", messages[1].Token);
         }
+#pragma warning restore CS0618
 
         [Fact]
-        public void GetMessageListNoTokens()
+        public void GetMessageListFids()
+        {
+            var message = new MulticastMessage
+            {
+                Fids = new[] { "test-fid1", "test-fid2" },
+            };
+
+            var messages = message.GetMessageList();
+
+            Assert.Equal(2, messages.Count);
+            Assert.Equal("test-fid1", messages[0].Fid);
+            Assert.Equal("test-fid2", messages[1].Fid);
+        }
+
+        [Fact]
+        public void GetMessageListNoTargets()
         {
             var message = new MulticastMessage();
 
             Assert.Throws<ArgumentException>(() => message.GetMessageList());
         }
 
+#pragma warning disable CS0618
+        [Fact]
+        public void GetMessageListBothTargets()
+        {
+            var message = new MulticastMessage
+            {
+                Tokens = new[] { "test-token1" },
+                Fids = new[] { "test-fid1" },
+            };
+
+            var messages = message.GetMessageList();
+
+            Assert.Equal(2, messages.Count);
+            Assert.Equal("test-token1", messages[0].Token);
+            Assert.Equal("test-fid1", messages[1].Fid);
+        }
+#pragma warning restore CS0618
+
+#pragma warning disable CS0618
         [Fact]
         public void GetMessageListTooManyTokens()
         {
@@ -54,5 +90,31 @@ namespace FirebaseAdmin.Tests.Messaging
 
             Assert.Throws<ArgumentException>(() => message.GetMessageList());
         }
+#pragma warning restore CS0618
+
+        [Fact]
+        public void GetMessageListTooManyFids()
+        {
+            var message = new MulticastMessage
+            {
+                Fids = Enumerable.Range(0, 501).Select(x => x.ToString()).ToList(),
+            };
+
+            Assert.Throws<ArgumentException>(() => message.GetMessageList());
+        }
+
+#pragma warning disable CS0618
+        [Fact]
+        public void GetMessageListTooManyCombinedTargets()
+        {
+            var message = new MulticastMessage
+            {
+                Tokens = Enumerable.Range(0, 250).Select(x => x.ToString()).ToList(),
+                Fids = Enumerable.Range(0, 251).Select(x => x.ToString()).ToList(),
+            };
+
+            Assert.Throws<ArgumentException>(() => message.GetMessageList());
+        }
+#pragma warning restore CS0618
     }
 }

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/FirebaseMessaging.cs
@@ -250,7 +250,8 @@ namespace FirebaseAdmin.Messaging
         }
 
         /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Sends the given multicast message to all the FCM registration tokens and FIDs specified in it.
+        /// The order of responses in the <see cref="BatchResponse"/> corresponds to the order of tokens, followed by the order of FIDs.
         /// Unlike <see cref="SendMulticastAsync(MulticastMessage)"/>, this method makes an
         /// HTTP call for each token in the given multicast message.
         /// </summary>
@@ -266,7 +267,8 @@ namespace FirebaseAdmin.Messaging
         }
 
         /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Sends the given multicast message to all the FCM registration tokens and FIDs specified in it.
+        /// The order of responses in the <see cref="BatchResponse"/> corresponds to the order of tokens, followed by the order of FIDs.
         /// Unlike <see cref="SendMulticastAsync(MulticastMessage, CancellationToken)"/>, this
         /// method makes an HTTP call for each token in the given multicast message.
         /// </summary>
@@ -284,7 +286,8 @@ namespace FirebaseAdmin.Messaging
         }
 
         /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Sends the given multicast message to all the FCM registration tokens and FIDs specified in it.
+        /// The order of responses in the <see cref="BatchResponse"/> corresponds to the order of tokens, followed by the order of FIDs.
         /// Unlike <see cref="SendMulticastAsync(MulticastMessage, bool)"/>, this method makes an
         /// HTTP call for each token in the given multicast message.
         /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
@@ -307,7 +310,8 @@ namespace FirebaseAdmin.Messaging
         }
 
         /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Sends the given multicast message to all the FCM registration tokens and FIDs specified in it.
+        /// The order of responses in the <see cref="BatchResponse"/> corresponds to the order of tokens, followed by the order of FIDs.
         /// Unlike <see cref="SendMulticastAsync(MulticastMessage, bool, CancellationToken)"/>,
         /// this method makes an HTTP call for each token in the given multicast message.
         /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
@@ -412,7 +416,8 @@ namespace FirebaseAdmin.Messaging
         }
 
         /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Sends the given multicast message to all the FCM registration tokens and FIDs specified in it.
+        /// The order of responses in the <see cref="BatchResponse"/> corresponds to the order of tokens, followed by the order of FIDs.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
@@ -427,7 +432,8 @@ namespace FirebaseAdmin.Messaging
         }
 
         /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Sends the given multicast message to all the FCM registration tokens and FIDs specified in it.
+        /// The order of responses in the <see cref="BatchResponse"/> corresponds to the order of tokens, followed by the order of FIDs.
         /// </summary>
         /// <exception cref="FirebaseMessagingException">If an error occurs while sending the
         /// messages.</exception>
@@ -444,7 +450,8 @@ namespace FirebaseAdmin.Messaging
         }
 
         /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Sends the given multicast message to all the FCM registration tokens and FIDs specified in it.
+        /// The order of responses in the <see cref="BatchResponse"/> corresponds to the order of tokens, followed by the order of FIDs.
         /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
         /// actually sent to the recipients. Instead, the FCM service performs all the necessary
         /// validations, and emulates the send operation. This is a good way to check if a
@@ -466,7 +473,8 @@ namespace FirebaseAdmin.Messaging
         }
 
         /// <summary>
-        /// Sends the given multicast message to all the FCM registration tokens specified in it.
+        /// Sends the given multicast message to all the FCM registration tokens and FIDs specified in it.
+        /// The order of responses in the <see cref="BatchResponse"/> corresponds to the order of tokens, followed by the order of FIDs.
         /// <para>If the <paramref name="dryRun"/> option is set to true, the message will not be
         /// actually sent to the recipients. Instead, the FCM service performs all the necessary
         /// validations, and emulates the send operation. This is a good way to check if a

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
@@ -144,7 +144,7 @@ namespace FirebaseAdmin.Messaging
             if (targets.Count != 1)
             {
                 throw new ArgumentException(
-                    "Exactly one of Token, Fid, Topic or Condition is required.");
+                    "Exactly one of Token, FID, Topic or Condition is required.");
             }
 
             var topic = copy.UnprefixedTopic;

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/Message.cs
@@ -22,16 +22,24 @@ namespace FirebaseAdmin.Messaging
     /// <summary>
     /// Represents a message that can be sent via Firebase Cloud Messaging (FCM). Contains payload
     /// information as well as the recipient information. The recipient information must be
-    /// specified by setting exactly one of the <see cref="Token"/>, <see cref="Topic"/> or
-    /// <see cref="Condition"/> fields.
+    /// specified by setting exactly one of the <see cref="Token"/>, <see cref="Fid"/>,
+    /// <see cref="Topic"/> or <see cref="Condition"/> fields.
     /// </summary>
     public sealed class Message
     {
         /// <summary>
         /// Gets or sets the registration token of the device to which the message should be sent.
+        /// Deprecated. Use <see cref="Fid"/> instead.
         /// </summary>
+        [Obsolete("Deprecated. Use Fid instead.")]
         [JsonProperty("token")]
         public string Token { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Firebase Installation ID (FID) of the device to which the message should be sent.
+        /// </summary>
+        [JsonProperty("fid")]
+        public string Fid { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the FCM topic to which the message should be sent. Topic names
@@ -116,10 +124,12 @@ namespace FirebaseAdmin.Messaging
         /// </summary>
         internal Message CopyAndValidate()
         {
+#pragma warning disable CS0618
             // Copy and validate the leaf-level properties
             var copy = new Message()
             {
                 Token = this.Token,
+                Fid = this.Fid,
                 Topic = this.Topic,
                 Condition = this.Condition,
                 Data = this.Data?.Copy(),
@@ -127,13 +137,14 @@ namespace FirebaseAdmin.Messaging
             };
             var list = new List<string>()
             {
-                copy.Token, copy.Topic, copy.Condition,
+                copy.Token, copy.Fid, copy.Topic, copy.Condition,
             };
+#pragma warning restore CS0618
             var targets = list.FindAll((target) => !string.IsNullOrEmpty(target));
             if (targets.Count != 1)
             {
                 throw new ArgumentException(
-                    "Exactly one of Token, Topic or Condition is required.");
+                    "Exactly one of Token, Fid, Topic or Condition is required.");
             }
 
             var topic = copy.UnprefixedTopic;

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/MessagingErrorCode.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/MessagingErrorCode.cs
@@ -50,7 +50,7 @@ namespace FirebaseAdmin.Messaging
         Unavailable,
 
         /// <summary>
-        /// App instance was unregistered from FCM. This usually means that the token used is no
+        /// App instance was unregistered from FCM. This usually means that the token or FID used is no
         /// longer valid and a new one must be used.
         /// </summary>
         Unregistered,

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
@@ -78,7 +78,7 @@ namespace FirebaseAdmin.Messaging
 
             if (totalCount == 0)
             {
-                throw new ArgumentException("Tokens and Fids cannot be both null or empty.");
+                throw new ArgumentException("Tokens and FIDs cannot be both null or empty.");
             }
 
             if (totalCount > 500)

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2018, Google Inc. All rights reserved.
+// Copyright 2018, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,16 +19,22 @@ namespace FirebaseAdmin.Messaging
 {
     /// <summary>
     /// Represents a message that can be sent to multiple devices via Firebase Cloud Messaging (FCM).
-    /// Contains payload information as well as the list of device registration tokens to which the
-    /// message should be sent. A single <c>MulticastMessage</c> may contain up to 500 registration
-    /// tokens.
+    /// Contains payload information as well as the list of device registration tokens and/or
+    /// Firebase Installation IDs (FIDs) to which the message should be sent. A single
+    /// <c>MulticastMessage</c> may contain up to 500 tokens and FIDs combined.
     /// </summary>
     public sealed class MulticastMessage
     {
         /// <summary>
         /// Gets or sets the registration tokens for the devices to which the message should be distributed.
         /// </summary>
+        [Obsolete("Deprecated. Use Fids instead.")]
         public IReadOnlyList<string> Tokens { get; set; }
+
+        /// <summary>
+        /// Gets or sets the installation IDs (FIDs) for the devices to which the message should be distributed.
+        /// </summary>
+        public IReadOnlyList<string> Fids { get; set; }
 
         /// <summary>
         /// Gets or sets a collection of key-value pairs that will be added to the message as data
@@ -58,14 +64,27 @@ namespace FirebaseAdmin.Messaging
 
         internal List<Message> GetMessageList()
         {
+#pragma warning disable CS0618
             var tokens = this.Tokens;
+#pragma warning restore CS0618
+            var fids = this.Fids;
 
-            if (tokens == null || tokens.Count > 500)
+            var tokensCopy = tokens != null ? new List<string>(tokens) : null;
+            var fidsCopy = fids != null ? new List<string>(fids) : null;
+
+            var tokensCount = tokensCopy?.Count ?? 0;
+            var fidsCount = fidsCopy?.Count ?? 0;
+            var totalCount = tokensCount + fidsCount;
+
+            if (totalCount == 0)
             {
-                throw new ArgumentException("Tokens must be non-null and contain at most 500 tokens.");
+                throw new ArgumentException("tokens and fids cannot be both null or empty");
             }
 
-            var tokensCopy = new List<string>(tokens);
+            if (totalCount > 500)
+            {
+                throw new ArgumentException("Total number of tokens and fids must not exceed 500.");
+            }
 
             var templateMessage = new Message
             {
@@ -76,20 +95,45 @@ namespace FirebaseAdmin.Messaging
                 Webpush = this.Webpush?.CopyAndValidate(),
             };
 
-            var messages = new List<Message>(tokensCopy.Count);
+            var messages = new List<Message>(totalCount);
 
-            foreach (var token in tokensCopy)
+            if (tokensCopy != null)
             {
-                var message = new Message
+                foreach (var token in tokensCopy)
                 {
-                    Android = templateMessage.Android,
-                    Apns = templateMessage.Apns,
-                    Data = templateMessage.Data,
-                    Notification = templateMessage.Notification,
-                    Webpush = templateMessage.Webpush,
-                    Token = token,
-                };
-                messages.Add(message);
+                    var message = new Message
+                    {
+                        Android = templateMessage.Android,
+                        Apns = templateMessage.Apns,
+                        Data = templateMessage.Data,
+                        Notification = templateMessage.Notification,
+                        Webpush = templateMessage.Webpush,
+                    };
+
+#pragma warning disable CS0618
+                    message.Token = token;
+#pragma warning restore CS0618
+
+                    messages.Add(message);
+                }
+            }
+
+            if (fidsCopy != null)
+            {
+                foreach (var fid in fidsCopy)
+                {
+                    var message = new Message
+                    {
+                        Android = templateMessage.Android,
+                        Apns = templateMessage.Apns,
+                        Data = templateMessage.Data,
+                        Notification = templateMessage.Notification,
+                        Webpush = templateMessage.Webpush,
+                        Fid = fid,
+                    };
+
+                    messages.Add(message);
+                }
             }
 
             return messages;

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
@@ -78,12 +78,12 @@ namespace FirebaseAdmin.Messaging
 
             if (totalCount == 0)
             {
-                throw new ArgumentException("tokens and fids cannot be both null or empty");
+                throw new ArgumentException("Tokens and Fids cannot be both null or empty.");
             }
 
             if (totalCount > 500)
             {
-                throw new ArgumentException("Total number of tokens and fids must not exceed 500.");
+                throw new ArgumentException("Total number of Tokens and Fids must not exceed 500.");
             }
 
             var templateMessage = new Message

--- a/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
+++ b/FirebaseAdmin/FirebaseAdmin/Messaging/MulticastMessage.cs
@@ -83,7 +83,7 @@ namespace FirebaseAdmin.Messaging
 
             if (totalCount > 500)
             {
-                throw new ArgumentException("Total number of Tokens and Fids must not exceed 500.");
+                throw new ArgumentException("Total number of Tokens and FIDs must not exceed 500.");
             }
 
             var templateMessage = new Message


### PR DESCRIPTION
This change deprecates `Token` (in `Message`) and `Tokens` (in `MulticastMessage`) as message targets, transitioning support to `Fid` (Firebase Installation ID) and `Fids` as the primary targets instead.

Legacy token tests are wrapped in Method-Level #pragma warning disable CS0618 to prevent compiler warnings and build crash and #pragma wrappers are explicitly maintained for snippet documentation code to allow compiling flawlessly.