### PR TITLE
fix(ci): Resolve zizmor security findings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,13 @@ name: Continuous Integration
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -19,6 +24,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,8 +22,13 @@ on:
   repository_dispatch:
     types: [firebase_nightly_build]
 
+permissions:
+  contents: read
+
 jobs:
   nightly:
+    permissions:
+      contents: read
 
     runs-on: ubuntu-latest
 
@@ -37,6 +42,7 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ github.event.client_payload.ref || github.ref }}
+        persist-credentials: false
         
 
     - name: Setup .NET

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
 
     # Login to NuGet using OIDC and generate a short-lived NuGet API key
     - name: Nuget login
-      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.1.0
       id: nuget_login
       with:
         user: ${{ secrets.NUGET_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,13 @@ on:
     types:
       - firebase_build
 
+permissions:
+  contents: read
+
 jobs:
   stage_release:
+    permissions:
+      contents: read
     # To publish a release, merge a PR with the title prefix '[chore] Release ' to main
     # and ensure the squashed commit message also has the prefix.
     # To stage a release without publishing it, send a 'firebase_build' event or apply
@@ -53,6 +58,8 @@ jobs:
     steps:
     - name: Checkout source for staging
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
 
     - name: Setup .NET
       uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
@@ -115,6 +122,9 @@ jobs:
     steps:
     - name: Checkout source for publish
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        # Ignored since the GITHUB_TOKEN needs to be persisted for this workflow.
+        persist-credentials: true # zizmor: ignore[artipacked]
 
     # Download the artifacts created by the stage_release job.
     - name: Download release candidates


### PR DESCRIPTION
This change resolves security findings diagnosed by zizmor (`artipacked` and `excessive-permissions`) across all GitHub Actions workflow YAML files (`ci.yml`, `nightly.yml`, and `release.yml`). Specifically, least-privilege permissions blocks have been added to the workflow and job definitions, and `persist-credentials: false` has been configured on git checkouts where git credentials are not required by subsequent steps.